### PR TITLE
Set LOCAL_MULTILIB as 64 bit for 1.0-vpu-service

### DIFF
--- a/vpu-hal2/Android.mk
+++ b/vpu-hal2/Android.mk
@@ -93,7 +93,7 @@ LOCAL_SHARED_LIBRARIES := \
 
 
 #LOCAL_MULTILIB := both
-#LOCAL_MULTILIB := 64
+LOCAL_MULTILIB := 64
 
 include $(BUILD_EXECUTABLE)
 #############################################################


### PR DESCRIPTION
- Keep it consistent with its depedency 1.0-vpu-impl
Otherwise it will cause ''missing dependency" error in some build environment.

Signed-off-by: Jerry Yu <jerry.yu@intel.com>