### PR TITLE
Bug fix: Allow early CPU fallback to happen when NCS is not connected.

### DIFF
--- a/Intel_movidius_nn_hal/vpuhal/src/vpu_driver/VpuDriver.cpp
+++ b/Intel_movidius_nn_hal/vpuhal/src/vpu_driver/VpuDriver.cpp
@@ -90,6 +90,13 @@ Return<void> VpuDriver::getSupportedOperations(const Model& model,
 Return<ErrorStatus> VpuDriver::prepareModel(const Model& model,
                                                const sp<IPreparedModelCallback>& callback) {
 
+    int devStatus;
+    devStatus = ncs_init();
+    if (devStatus){
+        ALOGE("Error - VpuDriver returning since NN device is disconnected/offline.");
+        return ErrorStatus::DEVICE_UNAVAILABLE;
+    }
+
     if (VLOG_IS_ON(DRIVER)) {
       VLOG(DRIVER) << "VpuDriver::prepareModel begin";
       logModelToInfo(model);


### PR DESCRIPTION
This patch stops the graph generation when the NCS is
not connected to the platform. This will in-turn
reduces the latency and graph file generation overhead
when the NN device is not available.

Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>