### PR TITLE
Fix member not initialized in the constructor

### DIFF
--- a/intel_nn_hal/graphTests/helpers-test.hpp
+++ b/intel_nn_hal/graphTests/helpers-test.hpp
@@ -247,7 +247,7 @@ class ExecuteNetwork {
     ResponseDesc resp;
 
    public:
-    ExecuteNetwork() {}
+    ExecuteNetwork() : network(nullptr) {}
     ExecuteNetwork(IRDocument &doc, TargetDevice target = TargetDevice::eCPU) : network(nullptr) {
         InferenceEngine::PluginDispatcher dispatcher(
             {"/vendor/lib64", "/vendor/lib", "/system/lib64", "/system/lib", "", "./"});


### PR DESCRIPTION
'this->network' is not initialized in ExecuteNetwork constructor
nn-hal/intel_nn_hal/graphTests/helpers-test.hpp:250

Tracked-On: OAM-83251
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>