### PR TITLE
Start NN GPU service 1.2 in Q

### DIFF
--- a/intel_nn_hal/Android.mk
+++ b/intel_nn_hal/Android.mk
@@ -90,7 +90,7 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.neuralnetworks@1.2-generic-service
 LOCAL_INIT_RC := android.hardware.neuralnetworks@1.2-generic-cpu.rc \
-    android.hardware.neuralnetworks@1.1-generic-gpu.rc
+    android.hardware.neuralnetworks@1.2-generic-gpu.rc
 LOCAL_MODULE_RELATIVE_PATH := hw
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_OWNER := intel

--- a/intel_nn_hal/android.hardware.neuralnetworks@1.2-generic-gpu.rc
+++ b/intel_nn_hal/android.hardware.neuralnetworks@1.2-generic-gpu.rc
@@ -1,0 +1,4 @@
+service neuralnetworks-hal-1-2-gpu /vendor/bin/hw/android.hardware.neuralnetworks@1.2-generic-service -D GPU
+    class hal
+    user system
+    group system


### PR DESCRIPTION
NN GPU service 1.1 is not longer integrated in Q, change to 1.2
accordingly.

Tracked-On: OAM-89830
Signed-off-by: Wan Shuang <shuang.wan@intel.com>