### PR TITLE
Creation of Network using ngraph operations

### DIFF
--- a/intel_nn_hal/Android.bp
+++ b/intel_nn_hal/Android.bp
@@ -22,6 +22,7 @@ cc_library_shared {
     ],
 
     header_libs: [
+        "libngraph_headers",
         "libinference_headers",
         "libmkldnn_headers",
         "libpugixml_headers",
@@ -80,6 +81,7 @@ cc_library_shared {
         "android.hidl.memory@1.0",
         "libinference_engine",
         "libinference_engine_legacy",
+        "libngraph",
     ],
 
     static_libs: [

--- a/intel_nn_hal/PreparedModel.cpp
+++ b/intel_nn_hal/PreparedModel.cpp
@@ -1150,8 +1150,8 @@ bool PreparedModel::initialize() {
 
     InferenceEngine::CNNNetwork ngraph_net;
 #ifdef USE_NGRAPH
-    ngraph_net = mCreateNgraph->generate(std::string("/data/vendor/ir/ngraph_ir.xml"), 
-		    std::string("/data/vendor/ir/ngraph_ir.bin"));
+    ngraph_net = mCreateNgraph->generate(std::string("/data/vendor/neuralnetworks/ngraph_ir.xml"),
+		    std::string("/data/vendor/neuralnetworks/ngraph_ir.bin"));
 #endif
     if (success == false) return success;
 

--- a/intel_nn_hal/PreparedModel.cpp
+++ b/intel_nn_hal/PreparedModel.cpp
@@ -796,19 +796,19 @@ OutputPort PreparedModel::handleFusion(const OutputPort& out, int32_t fusedOp) {
         VLOG(L1, "fusedOp is RELU");
         ret = ReLU(out);
 #ifdef USE_NGRAPH
-	mCreateNgraph->addRelu(ret->getName(), out->getName());
+        mCreateNgraph->addRelu(ret->getName(), out->getName());
 #endif
     } else if (fusedOp == (int32_t)FusedActivationFunc::RELU1) {
         VLOG(L1, "fusedOp is RELU1");
         ret = Clamp(out, -1, 1);
 #ifdef USE_NGRAPH
-	mCreateNgraph->addClamp(ret->getName(), out->getName(), -1, 1);
+        mCreateNgraph->addClamp(ret->getName(), out->getName(), -1, 1);
 #endif
     } else if (fusedOp == (int32_t)FusedActivationFunc::RELU6) {
         VLOG(L1, "fusedOp is RELU6");
         ret = Clamp(out, 0, 6);
 #ifdef USE_NGRAPH
-	mCreateNgraph->addClamp(ret->getName(), out->getName(), 0, 6);
+        mCreateNgraph->addClamp(ret->getName(), out->getName(), 0, 6);
 #endif
     }
 
@@ -935,7 +935,8 @@ OutputPort PreparedModel::getPort(int index) {
             operandName.str(), permuteDims(toDims(op.dimensions), order));  // NHWC -> NCHW
         mPorts[index] = operandInfo->getInputData();
 #ifdef USE_NGRAPH
-	mCreateNgraph->addInputParameter(operandName.str(), mPorts[index]->getTensorDesc().getDims());
+        mCreateNgraph->addInputParameter(operandName.str(),
+                                         mPorts[index]->getTensorDesc().getDims());
 #endif
         // TODO: workaround 3-D
         int dims_size = op.dimensions.size();
@@ -1151,7 +1152,7 @@ bool PreparedModel::initialize() {
     InferenceEngine::CNNNetwork ngraph_net;
 #ifdef USE_NGRAPH
     ngraph_net = mCreateNgraph->generate(std::string("/data/vendor/neuralnetworks/ngraph_ir.xml"),
-		    std::string("/data/vendor/neuralnetworks/ngraph_ir.bin"));
+                                         std::string("/data/vendor/neuralnetworks/ngraph_ir.bin"));
 #endif
     if (success == false) return success;
 
@@ -1192,8 +1193,9 @@ void printBuffer(int level, T* buf, int num, int items, const char* format, uint
         n = (n + items) > num ? num : n + items;
         offset = snprintf(str, sizeof(str) - strnlen(str, maxlen), "[%d->%d]:\t", start, n);
         for (int i = start; i < n; i++) {
-            if (i<buf_len) {
-                offset += snprintf(str + offset, sizeof(str) - strnlen(str, maxlen), format, buf[i]);
+            if (i < buf_len) {
+                offset +=
+                    snprintf(str + offset, sizeof(str) - strnlen(str, maxlen), format, buf[i]);
             }
         }
         start = n;
@@ -1201,13 +1203,13 @@ void printBuffer(int level, T* buf, int num, int items, const char* format, uint
     }
 }
 
-void printOperandbuf(int level, const uint8_t* buffer, const std::vector<uint32_t>& dims, uint32_t buffer_length,
-                     int limit = 0) {
+void printOperandbuf(int level, const uint8_t* buffer, const std::vector<uint32_t>& dims,
+                     uint32_t buffer_length, int limit = 0) {
     auto dimsize = dims.size();
     auto type = OperandType::TENSOR_FLOAT32;  // operand.type;
     int size = 1;
     for (int i = 0; i < dimsize; i++) size *= dims[i];
-    
+
     if (limit > 0 && limit < size) size = limit;
 
     if (type == OperandType::TENSOR_FLOAT32) {
@@ -1246,7 +1248,7 @@ void PreparedModel::asyncExecute(const Request& request, MeasureTiming measure,
 
     auto inOutData = [this, &requestPoolInfos](const std::vector<uint32_t>& indexes,
                                                const hidl_vec<RequestArgument>& arguments,
-                                               bool inputFromRequest,ExecuteNetwork* enginePtr,
+                                               bool inputFromRequest, ExecuteNetwork* enginePtr,
                                                std::vector<OutputPort> mPorts) {
         // do memcpy for input data
         for (size_t i = 0; i < indexes.size(); i++) {
@@ -1564,10 +1566,11 @@ Return<void> PreparedModel::executeSynchronously(const Request& request, Measure
                     operand.length);  // if not doing memcpy
                 VLOG(L1, "Copy inputBlob for mPorts[%d]->name %s", indexes[i],
 #ifdef USE_NGRAPH
-                    mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName()).c_str());
-                auto destBlob = (mUseNgraph == true) ?
-                     enginePtr->getBlob(mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName())) :
-                        enginePtr->getBlob(mPorts[indexes[i]]->getName());
+                     mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName()).c_str());
+                auto destBlob = (mUseNgraph == true)
+                                    ? enginePtr->getBlob(
+                                          mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName()))
+                                    : enginePtr->getBlob(mPorts[indexes[i]]->getName());
 #else
                      mPorts[indexes[i]]->getName().c_str());
 
@@ -1580,9 +1583,10 @@ Return<void> PreparedModel::executeSynchronously(const Request& request, Measure
                 VLOG(L1, "copyData from IE to Android blob for mPorts[%d]->name %s", indexes[i],
 #ifdef USE_NGRAPH
                      mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName()).c_str());
-                auto srcBlob = (mUseNgraph == true) ?
-                     enginePtr->getBlob(mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName())) :
-                        enginePtr->getBlob(mPorts[indexes[i]]->getName());
+                auto srcBlob = (mUseNgraph == true)
+                                   ? enginePtr->getBlob(
+                                         mCreateNgraph->getNodeName(mPorts[indexes[i]]->getName()))
+                                   : enginePtr->getBlob(mPorts[indexes[i]]->getName());
 #else
                      mPorts[indexes[i]]->getName().c_str());
                 auto srcBlob = enginePtr->getBlob(mPorts[indexes[i]]->getName());
@@ -1616,18 +1620,18 @@ Return<void> PreparedModel::executeSynchronously(const Request& request, Measure
 
     InferenceEngine::TBlob<float>::Ptr outBlob =
 #ifdef USE_NGRAPH
-        (mUseNgraph == true) ?
-        enginePtr->getBlob(mCreateNgraph->getNodeName(mPorts[mModel.outputIndexes[0]]->getName())) :
-        enginePtr->getBlob(mPorts[mModel.outputIndexes[0]]->getName());
+        (mUseNgraph == true) ? enginePtr->getBlob(mCreateNgraph->getNodeName(
+                                   mPorts[mModel.outputIndexes[0]]->getName()))
+                             : enginePtr->getBlob(mPorts[mModel.outputIndexes[0]]->getName());
 #else
         enginePtr->getBlob(mPorts[mModel.outputIndexes[0]]->getName());
 #endif
 
     InferenceEngine::TBlob<float>::Ptr inBlob =
 #ifdef USE_NGRAPH
-        (mUseNgraph == true) ?
-        enginePtr->getBlob(mCreateNgraph->getNodeName(mPorts[mModel.inputIndexes[0]]->getName())):
-        enginePtr->getBlob(mPorts[mModel.inputIndexes[0]]->getName());
+        (mUseNgraph == true) ? enginePtr->getBlob(mCreateNgraph->getNodeName(
+                                   mPorts[mModel.inputIndexes[0]]->getName()))
+                             : enginePtr->getBlob(mPorts[mModel.inputIndexes[0]]->getName());
 #else
         enginePtr->getBlob(mPorts[mModel.inputIndexes[0]]->getName());
 #endif
@@ -2021,7 +2025,7 @@ bool PreparedModel::isOperationSupported(const Operation& operation, const Model
 #ifdef USE_NGRAPH
         case OperationType::CONCATENATION:
         case OperationType::RESHAPE:
-            if (!isNgraphPropSet()) //TODO:using this API as mUseNgraph is non-static
+            if (!isNgraphPropSet())  // TODO:using this API as mUseNgraph is non-static
             {
                 VLOG(L1, "operation supported only for ngraph %d", operation.type);
                 return false;
@@ -2123,8 +2127,10 @@ bool PreparedModel::operationAdd(const Operation& operation) {
     mPorts[operation.outputs[0]] = handleFusion(out, PARAM_I32(2));
 
     VLOG(L1, "add mPorts[%d]->name %s + mPorts[%d]->name %s  = mPorts[%d]->name %s \n",
-         operation.inputs[0], isIn0Const ? "isIn0Const" : mPorts[operation.inputs[0]]->getName().c_str(),
-         operation.inputs[1], isIn1Const ? "isIn1Const" : mPorts[operation.inputs[1]]->getName().c_str(),
+         operation.inputs[0],
+         isIn0Const ? "isIn0Const" : mPorts[operation.inputs[0]]->getName().c_str(),
+         operation.inputs[1],
+         isIn1Const ? "isIn1Const" : mPorts[operation.inputs[1]]->getName().c_str(),
          operation.outputs[0], mPorts[operation.outputs[0]]->getName().c_str());
 
     return true;
@@ -2390,14 +2396,15 @@ bool PreparedModel::operationConCat(const Operation& operation) {
     const auto op = mModel.operands[operation.inputs[0]];
     auto input = getPort(operation.inputs[0]);
     auto inDims = input->getTensorDesc().getDims();
-        if (op.dimensions.size() == 4) {
-            std::vector<uint32_t> axisMap = {2, 3, 1}; //NCHW = axisMap[NHWC]
-            axis = axisMap[PARAM_I32(n)];
-        } else if (op.dimensions.size() == 3) {
-            std::vector<uint32_t> axisMap = {2, 3, 1}; //NCHW = axisMap[HWC]
-            axis = axisMap[PARAM_I32(n)];
-        }
-     VLOG(L1, "shape of output tensor axis %d inDims size %d, op_dimensionsize %d", axis, inDims.size(), op.dimensions.size());
+    if (op.dimensions.size() == 4) {
+        std::vector<uint32_t> axisMap = {2, 3, 1};  // NCHW = axisMap[NHWC]
+        axis = axisMap[PARAM_I32(n)];
+    } else if (op.dimensions.size() == 3) {
+        std::vector<uint32_t> axisMap = {2, 3, 1};  // NCHW = axisMap[HWC]
+        axis = axisMap[PARAM_I32(n)];
+    }
+    VLOG(L1, "shape of output tensor axis %d inDims size %d, op_dimensionsize %d", axis,
+         inDims.size(), op.dimensions.size());
 #else
     if (getPort(operation.inputs[0])->getLayout() == InferenceEngine::NCHW) {
         std::vector<uint32_t> axisMap = {0, 2, 3, 1};
@@ -2410,8 +2417,7 @@ bool PreparedModel::operationConCat(const Operation& operation) {
     auto out = Concat(inputs, axis);
 #ifdef USE_NGRAPH
     std::vector<std::string> inputNames;
-    for (int i = 0; i < inputs.size(); ++i)
-    {
+    for (int i = 0; i < inputs.size(); ++i) {
         inputNames.push_back(inputs[i]->getName());
     }
     mCreateNgraph->addConcat(out->getName(), inputNames, axis);
@@ -3135,8 +3141,7 @@ bool PreparedModel::operationReshape(const Operation& operation) {
     auto numOutputElements = 1;  // shape
 #ifdef USE_NGRAPH
     VLOG(L1, "mModel outDims size[%d] ", outDims.size());
-    if (mUseNgraph == true && outDims.size() == 3)
-        outDims.insert(outDims.begin(), 1);
+    if (mUseNgraph == true && outDims.size() == 3) outDims.insert(outDims.begin(), 1);
 #endif
     for (auto i = 0; i < outDims.size(); i++) {
         VLOG(L1, "operand1: shape of output tensor outDims[%d] = %d ", i, outDims[i]);
@@ -3942,7 +3947,7 @@ Blob::Ptr CpuPreparedModel::GetInOutOperandAsBlob(RunTimeOperandInfo& op, const 
                 // order = {0, 1};
                 layout = Layout::NC;
             } else if (op.dimensions.size() == 3) {
-                //order = {0, 1, 2, 3};  // nhwc -> nchw
+                // order = {0, 1, 2, 3};  // nhwc -> nchw
                 layout = Layout::CHW;
                 ALOGI("Anoob : GetInOutOperandAsBlob output already transposed to NHWC");
             } else {

--- a/intel_nn_hal/PreparedModel.h
+++ b/intel_nn_hal/PreparedModel.h
@@ -133,7 +133,8 @@ public:
           mPadreq(EXPL_PAD) {
         g_layer_precision = InferenceEngine::Precision::FP16;
 #ifdef USE_NGRAPH
-        mUseNgraph = isNgraphPropSet(); //TODO:Should additionally check if all the ops are supported
+        mUseNgraph =
+            isNgraphPropSet();  // TODO:Should additionally check if all the ops are supported
         mCreateNgraph = std::make_shared<CreateNgraph>();
 #endif
     }
@@ -175,7 +176,7 @@ public:
     static bool isOperationSupported(const Operation& operation, const Model& model);
 #ifdef USE_NGRAPH
     void ConvertBlobToNHWC(InferenceEngine::TBlob<float>::Ptr blob, uint8_t* buf,
-                    std::vector<uint32_t> opDims);
+                           std::vector<uint32_t> opDims);
 #endif
 
 protected:

--- a/intel_nn_hal/graphAPI/Android.bp
+++ b/intel_nn_hal/graphAPI/Android.bp
@@ -11,6 +11,7 @@ cc_library_static {
     ],
 
     header_libs: [
+        "libngraph_headers",
         "libinference_headers",
         "libpugixml_headers",
         "plugin_api_headers",
@@ -36,5 +37,8 @@ cc_library_static {
         "-DIE_LEGACY",
     ],
 
-    shared_libs: ["liblog"],
+    shared_libs: [
+        "liblog",
+        "libngraph",
+    ],
 }

--- a/intel_nn_hal/graphAPI/IENetwork.h
+++ b/intel_nn_hal/graphAPI/IENetwork.h
@@ -41,7 +41,7 @@
 #include "ie_plugin_cpp.hpp"
 #else
 #include <ie_core.hpp>
-#endif // IE_LEGACY
+#endif  // IE_LEGACY
 
 #include <android/log.h>
 #include <log/log.h>
@@ -134,7 +134,7 @@ class ExecuteNetwork {
     InferenceEnginePluginPtr enginePtr;
 #else
     CNNNetwork mCnnNetwork;
-#endif // IE_LEGACY
+#endif  // IE_LEGACY
     ICNNNetwork *network;
     // IExecutableNetwork::Ptr pExeNet;
     ExecutableNetwork executable_network;
@@ -148,21 +148,21 @@ class ExecuteNetwork {
 #endif
 
 public:
-    ExecuteNetwork() : network(nullptr) {
-    }
+    ExecuteNetwork() : network(nullptr) {}
 #ifdef USE_NGRAPH
-    ExecuteNetwork(CNNNetwork ngraphNetwork, IRDocument &doc,  std::string target = "CPU") : network(nullptr) {
+    ExecuteNetwork(CNNNetwork ngraphNetwork, IRDocument &doc, std::string target = "CPU")
+        : network(nullptr) {
         mNgraphProp = isNgraphPropSet();
 #else
-    ExecuteNetwork(IRDocument &doc,  std::string target = "CPU") : network(nullptr) {
+    ExecuteNetwork(IRDocument &doc, std::string target = "CPU") : network(nullptr) {
 #endif
 #ifdef IE_LEGACY
         InferenceEngine::PluginDispatcher dispatcher(
             {"/vendor/lib64", "/vendor/lib", "/system/lib64", "/system/lib", "", "./"});
         enginePtr = dispatcher.getPluginByDevice(target);
-#endif // IE_LEGACY
+#endif  // IE_LEGACY
 #ifdef USE_NGRAPH
-        if(mNgraphProp) {
+        if (mNgraphProp) {
             inputInfo = ngraphNetwork.getInputsInfo();
             outputInfo = ngraphNetwork.getOutputsInfo();
         } else
@@ -175,21 +175,21 @@ public:
 
 #ifndef IE_LEGACY
 #ifdef USE_NGRAPH
-        if(!mNgraphProp)
+        if (!mNgraphProp)
 #endif
         {
             std::shared_ptr<InferenceEngine::ICNNNetwork> sp_cnnNetwork;
             sp_cnnNetwork.reset(network);
             mCnnNetwork = InferenceEngine::CNNNetwork(sp_cnnNetwork);
         }
-#endif // IE_LEGACY
+#endif  // IE_LEGACY
         // size_t batch = 1;
         // network->setBatchSize(batch);
 
 #ifdef NNLOG
 #ifdef IE_LEGACY
         ALOGI("%s Plugin loaded", InferenceEngine::TargetDeviceInfo::name(target));
-#endif // IE_LEGACY
+#endif  // IE_LEGACY
 #endif
     }
 
@@ -201,36 +201,36 @@ public:
 
     //~ExecuteNetwork(){ }
 #ifdef USE_NGRAPH
-    void loadNetwork(CNNNetwork ngraphNetwork) {
+    void loadNetwork(CNNNetwork ngraphNetwork){
 #else
     void loadNetwork() {
 #endif
 #ifdef IE_LEGACY
         std::map<std::string, std::string> networkConfig;
-        InferencePlugin plugin(enginePtr);
+    InferencePlugin plugin(enginePtr);
 
-        setConfig(networkConfig);
+    setConfig(networkConfig);
 
-        ALOGI("%s before plugin.LoadNetwork()", __func__);
-        executable_network = plugin.LoadNetwork(*network, networkConfig);
+    ALOGI("%s before plugin.LoadNetwork()", __func__);
+    executable_network = plugin.LoadNetwork(*network, networkConfig);
 
-        ALOGI("%s before CreateInferRequest", __func__);
-        inferRequest = executable_network.CreateInferRequest();
+    ALOGI("%s before CreateInferRequest", __func__);
+    inferRequest = executable_network.CreateInferRequest();
 #else
         Core ie_core(std::string("/vendor/etc/openvino/plugins.xml"));
 
 #ifdef USE_NGRAPH
-    try {
-        if(mNgraphProp == true) {
-            ALOGI("%s LoadNetwork actually using ngraphNetwork", __func__);
-            executable_network = ie_core.LoadNetwork(ngraphNetwork, std::string("CPU"));
-        } else {
-            ALOGI("%s LoadNetwork actually using mCnnNetwork", __func__);
-            executable_network = ie_core.LoadNetwork(mCnnNetwork, std::string("CPU"));
+        try {
+            if (mNgraphProp == true) {
+                ALOGI("%s LoadNetwork actually using ngraphNetwork", __func__);
+                executable_network = ie_core.LoadNetwork(ngraphNetwork, std::string("CPU"));
+            } else {
+                ALOGI("%s LoadNetwork actually using mCnnNetwork", __func__);
+                executable_network = ie_core.LoadNetwork(mCnnNetwork, std::string("CPU"));
+            }
+        } catch (const std::exception &ex) {
+            ALOGE("%s Exception !!! %s", __func__, ex.what());
         }
-    } catch (const std::exception& ex) {
-        ALOGE("%s Exception !!! %s", __func__, ex.what());
-    }
 #else
         ALOGI("%s Loading network to IE", __func__);
         executable_network = ie_core.LoadNetwork(mCnnNetwork, std::string("CPU"));
@@ -238,117 +238,117 @@ public:
 
         ALOGI("%s Calling CreateInferRequest", __func__);
         inferRequest = executable_network.CreateInferRequest();
-#endif // IE_LEGACY
-    }
+#endif  // IE_LEGACY
+}
 
     void prepareInput() {
 #ifdef NNLOG
-        ALOGI("Prepare input blob");
+    ALOGI("Prepare input blob");
 #endif
-        Precision inputPrecision = Precision::FP32;
-        inputInfo.begin()->second->setPrecision(inputPrecision);
-        // inputInfo.begin()->second->setPrecision(Precision::U8);
+    Precision inputPrecision = Precision::FP32;
+    inputInfo.begin()->second->setPrecision(inputPrecision);
+    // inputInfo.begin()->second->setPrecision(Precision::U8);
 
-        auto inputDims = inputInfo.begin()->second->getTensorDesc().getDims();
-        if (inputDims.size() == 4)
-            inputInfo.begin()->second->setLayout(Layout::NCHW);
-        else if (inputDims.size() == 2)
-            inputInfo.begin()->second->setLayout(Layout::NC);
-        else
-            inputInfo.begin()->second->setLayout(Layout::C);
+    auto inputDims = inputInfo.begin()->second->getTensorDesc().getDims();
+    if (inputDims.size() == 4)
+        inputInfo.begin()->second->setLayout(Layout::NCHW);
+    else if (inputDims.size() == 2)
+        inputInfo.begin()->second->setLayout(Layout::NC);
+    else
+        inputInfo.begin()->second->setLayout(Layout::C);
 
-        // inputInfo.begin()->second->setPrecision(Precision::U8);
-        // inputInfo.begin()->second->setLayout(Layout::NCHW);
-    }
+    // inputInfo.begin()->second->setPrecision(Precision::U8);
+    // inputInfo.begin()->second->setLayout(Layout::NCHW);
+}
 
-    void prepareOutput() {
+void prepareOutput() {
 #ifdef NNLOG
-        ALOGI("Prepare output blob");
+    ALOGI("Prepare output blob");
 #endif
-        Precision outputPrecision = Precision::FP32;
-        outputInfo.begin()->second->setPrecision(outputPrecision);
+    Precision outputPrecision = Precision::FP32;
+    outputInfo.begin()->second->setPrecision(outputPrecision);
 
-        auto outputDims = outputInfo.begin()->second->getDims();
-        if (outputDims.size() == 4)
-            outputInfo.begin()->second->setLayout(Layout::NHWC);
-        else if (outputDims.size() == 2)
-            outputInfo.begin()->second->setLayout(Layout::NC);
-        else
-            outputInfo.begin()->second->setLayout(Layout::C);
+    auto outputDims = outputInfo.begin()->second->getDims();
+    if (outputDims.size() == 4)
+        outputInfo.begin()->second->setLayout(Layout::NHWC);
+    else if (outputDims.size() == 2)
+        outputInfo.begin()->second->setLayout(Layout::NC);
+    else
+        outputInfo.begin()->second->setLayout(Layout::C);
 
 #ifdef NNLOG
 // auto dims = inputInfo.begin()->second->getDims();
 // ALOGI("inputInfo dims size = %d\n", dims.size());
 // ALOGI("outputInfo dims size = %d\n", outputDims.size());
 #endif
-    }
+}
 
-    // setBlob input/output blob for infer request
-    void setBlob(const std::string &inName, const Blob::Ptr &inputBlob) {
+// setBlob input/output blob for infer request
+void setBlob(const std::string &inName, const Blob::Ptr &inputBlob) {
 #ifdef NNLOG
-        ALOGI("setBlob input or output blob name : %s", inName.c_str());
-        ALOGI("Blob size %d and size in bytes %d bytes element size %d bytes", inputBlob->size(),
-              inputBlob->byteSize(), inputBlob->element_size());
+    ALOGI("setBlob input or output blob name : %s", inName.c_str());
+    ALOGI("Blob size %d and size in bytes %d bytes element size %d bytes", inputBlob->size(),
+          inputBlob->byteSize(), inputBlob->element_size());
 #endif
 
-        // inferRequest.SetBlob(inName.c_str(), inputBlob);
-        inferRequest.SetBlob(inName, inputBlob);
+    // inferRequest.SetBlob(inName.c_str(), inputBlob);
+    inferRequest.SetBlob(inName, inputBlob);
 
-        // std::cout << "setBlob input or output name : " << inName << std::endl;
-    }
+    // std::cout << "setBlob input or output name : " << inName << std::endl;
+}
 
-    // for non aync infer request
-    TBlob<float>::Ptr getBlob(const std::string &outName) {
-        Blob::Ptr outputBlob;
-        outputBlob = inferRequest.GetBlob(outName);
+// for non aync infer request
+TBlob<float>::Ptr getBlob(const std::string &outName) {
+    Blob::Ptr outputBlob;
+    outputBlob = inferRequest.GetBlob(outName);
 // std::cout << "GetBlob input or output name : " << outName << std::endl;
 #ifdef NNLOG
-        ALOGI("Get input/output blob, name : ", outName.c_str());
+    ALOGI("Get input/output blob, name : ", outName.c_str());
 #endif
-        return As<TBlob<float>>(outputBlob);
-        // return outputBlob;
-    }
+    return As<TBlob<float>>(outputBlob);
+    // return outputBlob;
+}
 
-    void Infer() {
+void Infer() {
 #ifdef NNLOG
-        ALOGI("Infer Network\n");
+    ALOGI("Infer Network\n");
 #endif
-        //        inferRequest = executable_network.CreateInferRequest();
-        /*
-                auto inName = inputInfo.begin()->first;
-                ALOGI("set input blob\n");
-                inferRequest.SetBlob(inName, in);
+    //        inferRequest = executable_network.CreateInferRequest();
+    /*
+            auto inName = inputInfo.begin()->first;
+            ALOGI("set input blob\n");
+            inferRequest.SetBlob(inName, in);
 
-                ALOGI("aks prepare output blob\n");
-                const std::string firstOutName = outputInfo.begin()->first;
-                InferenceEngine::TBlob<PrecisionTrait<Precision::FP32>::value_type>::Ptr outputBlob;
-                outputBlob =
-           InferenceEngine::make_shared_blob<PrecisionTrait<Precision::FP32>::value_type,
-                        InferenceEngine::SizeVector>(Precision::FP32,
-           outputInfo.begin()->second->getDims()); outputBlob->allocate();
+            ALOGI("aks prepare output blob\n");
+            const std::string firstOutName = outputInfo.begin()->first;
+            InferenceEngine::TBlob<PrecisionTrait<Precision::FP32>::value_type>::Ptr outputBlob;
+            outputBlob =
+       InferenceEngine::make_shared_blob<PrecisionTrait<Precision::FP32>::value_type,
+                    InferenceEngine::SizeVector>(Precision::FP32,
+       outputInfo.begin()->second->getDims()); outputBlob->allocate();
 
-                ALOGI("set output blob\n");
-                inferRequest.SetBlob(firstOutName, outputBlob);
+            ALOGI("set output blob\n");
+            inferRequest.SetBlob(firstOutName, outputBlob);
 
-        */
+    */
 #ifdef NNLOG
-        ALOGI("StartAsync scheduled");
+    ALOGI("StartAsync scheduled");
 #endif
-        inferRequest.StartAsync();  // for async infer
-        // ALOGI("async wait");
-        // inferRequest.Wait(1000);
-        inferRequest.Wait(10000);  // check right value to infer
+    inferRequest.StartAsync();  // for async infer
+    // ALOGI("async wait");
+    // inferRequest.Wait(1000);
+    inferRequest.Wait(10000);  // check right value to infer
 // inferRequest.Wait(IInferRequest::WaitMode::RESULT_READY);
 
 // std::cout << "output name : " << firstOutName << std::endl;
 #ifdef NNLOG
-        ALOGI("infer request completed");
+    ALOGI("infer request completed");
 #endif
 
-        return;
-    }
-};
-}  // namespace nnhal
+    return;
+}
+};  // namespace nnhal
 }  // namespace neuralnetworks
 }  // namespace hardware
+}  // namespace android
 }  // namespace android

--- a/intel_nn_hal/graphAPI/IENetwork.h
+++ b/intel_nn_hal/graphAPI/IENetwork.h
@@ -124,7 +124,7 @@ static void setConfig(std::map<std::string, std::string> &config) {
 
 #ifdef USE_NGRAPH
 static bool isNgraphPropSet() {
-    const char ngIrProp[] = "nn.hal.ngraph";
+    const char ngIrProp[] = "vendor.nn.hal.ngraph";
     return property_get_bool(ngIrProp, false);
 }
 #endif

--- a/intel_nn_hal/graphAPI/IRDocument.cpp
+++ b/intel_nn_hal/graphAPI/IRDocument.cpp
@@ -193,7 +193,6 @@ void IRDocument::saveBlobToIR(std::ostream &binFile,
 
     auto precision = blob->getTensorDesc().getPrecision();
     node.append_attribute("precision").set_value(precision.name());
-
 }
 
 void IRDocument::save(std::ostream &xml_os, std::ostream &bin_os) {

--- a/intel_nn_hal/graphAPI/IRLayers.h
+++ b/intel_nn_hal/graphAPI/IRLayers.h
@@ -305,15 +305,16 @@ struct GenConvParams {
     std::vector<std::ptrdiff_t> pads_begin;
     std::vector<std::ptrdiff_t> pads_end;
     std::vector<size_t> dilations;
-    const char* pad_type;
+    const char *pad_type;
 };
 
-inline void ConvolutionParamsToGenConvParams(ConvolutionParams &cPrms, GenConvParams & gPrms, IRBlob::Ptr weights, IRBlob::Ptr biases) {
+inline void ConvolutionParamsToGenConvParams(ConvolutionParams &cPrms, GenConvParams &gPrms,
+                                             IRBlob::Ptr weights, IRBlob::Ptr biases) {
     gPrms.groups = cPrms.groups;
-    float* buffer = weights->buffer().as<float*>();
+    float *buffer = weights->buffer().as<float *>();
     gPrms.weightsBuf = {buffer, buffer + weights->size()};
     gPrms.weightsDims = weights->getTensorDesc().getDims();
-    buffer = biases->buffer().as<float*>();
+    buffer = biases->buffer().as<float *>();
     gPrms.biasesBuf = {buffer, buffer + biases->size()};
     gPrms.biasesDims = biases->getTensorDesc().getDims();
     gPrms.strides = {(size_t)cPrms.stride.x, (size_t)cPrms.stride.y};

--- a/intel_nn_hal/graphAPI/create_ngraph.hpp
+++ b/intel_nn_hal/graphAPI/create_ngraph.hpp
@@ -1,0 +1,201 @@
+#include <ngraph/ngraph.hpp>
+#include <ngraph/opsets/opset3.hpp>
+#include <inference_engine.hpp>
+#define NNLOG1
+
+#include "IRLayers.h"
+#ifdef NNLOG1
+#define LOG_TAG "CreateNgraph"
+#include <android/log.h>
+#include <log/log.h>
+#define LOGDIMS(d, header)                                                         \
+    do {                                                                               \
+        auto size = (d).size();                                                        \
+        ALOGD("%s: vectors {%d, %d, %d, %d}", header, (d)[0], size > 1 ? (d)[1] : 0, \
+             size > 2 ? (d)[2] : 0, size > 3 ? (d)[3] : 0);                            \
+    } while (0)
+#endif
+
+namespace android {
+namespace hardware {
+namespace neuralnetworks {
+namespace nnhal {
+class CreateNgraph {
+private:
+    std::map<std::string, std::shared_ptr<ngraph::Node> > mNodes;
+    ngraph::ParameterVector mInputParams;
+    std::shared_ptr<ngraph::Node> mLastNode;
+    std::vector<std::shared_ptr<ngraph::Node>> mResultNodes;
+public:
+    InferenceEngine::CNNNetwork generate(std::string xmlPath, std::string binPath) {
+#ifdef NNLOG1
+        ALOGD("%s : Called", __func__);
+#endif
+        InferenceEngine::CNNNetwork cnn_n;
+        try {
+        auto ngraph_function = std::make_shared<ngraph::Function>(mResultNodes, mInputParams);
+        InferenceEngine::CNNNetwork cnn = InferenceEngine::CNNNetwork(ngraph_function);
+        //InferenceEngine::ResponseDesc resp;
+        cnn.serialize(xmlPath, binPath);
+        return cnn;
+        } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+        }
+        return cnn_n;
+    }
+    void addNode(std::string nodeName, std::shared_ptr<ngraph::Node> node) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s adding node : %s", __func__, nodeName.c_str(), node->get_name().c_str());
+#endif
+        mLastNode = node;
+        mNodes[nodeName] = node;
+    }
+    std::string getNodeName(std::string nodeName) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s ", __func__, nodeName.c_str());
+#endif
+        return mNodes[nodeName]->get_name();
+    }
+    void setResultNode(std::string nodeName) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s ", __func__, nodeName.c_str());
+#endif
+    //Transpose to NHWC for the Result node
+    ngraph::AxisVector order{0, 2, 3, 1};
+    const auto order_node = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{order.size()}, order);
+    std::string tempNodeName = nodeName + "_preNode";
+    mNodes[tempNodeName] = mNodes[nodeName];
+    auto transpose = std::make_shared<ngraph::opset3::Transpose>(mNodes[tempNodeName], order_node);
+    addNode(nodeName, transpose);
+    mResultNodes.push_back(mNodes[nodeName]);
+    }
+    void addInputParameter(std::string nodeName, std::vector<size_t> shape) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s ", __func__, nodeName.c_str());
+        LOGDIMS(shape, __func__);
+#endif
+        std::shared_ptr<ngraph::opset3::Parameter> input = std::make_shared<ngraph::opset3::Parameter>(ngraph::element::f32, ngraph::Shape(shape));
+        mInputParams.push_back(input);
+        addNode(nodeName, input);
+    }
+    void addClamp(std::string nodeName, std::string inputName, const double min, const double max) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s inputName=%s ", __func__, nodeName.c_str(), inputName.c_str());
+#endif
+        addNode(nodeName, std::make_shared<ngraph::opset3::Clamp>(mNodes[inputName], min, max));
+    }
+    void addRelu(std::string nodeName, std::string inputName) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s inputName=%s ", __func__, nodeName.c_str(), inputName.c_str());
+#endif
+        addNode(nodeName, std::make_shared<ngraph::opset3::Relu>(mNodes[inputName]));
+    }
+    void addReshape(std::string nodeName, std::string inputName, std::vector<size_t> shape) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s inputName=%s ", __func__, nodeName.c_str(), inputName.c_str());
+#endif
+        try {
+//Pre Transpose [[ NCHW > NHWC
+    ngraph::AxisVector pre_order{0, 2, 3, 1};
+    const auto pre_order_node = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{pre_order.size()}, pre_order);
+    std::string preNodeName = nodeName + "_priorTranspose";
+    auto pre_transpose = std::make_shared<ngraph::opset3::Transpose>(mNodes[inputName], pre_order_node);
+    addNode(preNodeName, pre_transpose);
+//Pre Transpose ]]
+        auto shapeNode = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{shape.size()}, shape.data());
+        std::string currNodeName = nodeName + "_actualReshape";
+            addNode(currNodeName, std::make_shared<ngraph::opset3::Reshape>(mNodes[preNodeName], shapeNode, true));
+
+//Post Transpose [[ NHWC > NCHW
+    ngraph::AxisVector post_order{0, 3, 1, 2};
+    const auto post_order_node = ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{post_order.size()}, post_order);
+    auto post_transpose = std::make_shared<ngraph::opset3::Transpose>(mNodes[currNodeName], post_order_node);
+    addNode(nodeName, post_transpose); //while adding a new node connected to this node, inputName passed will be the current nodeName. Hence, the Post Transpose node should be mapped to it.
+//Post Transpose ]]
+        } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+        }
+    }
+    void addConcat(std::string nodeName, std::vector<std::string> inputNames, int axis) {
+        std::string str;
+        for (const auto &name : inputNames) str = str + name + ";";
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s inputNames=%s ", __func__, nodeName.c_str(), str.c_str());
+#endif
+        std::vector<std::shared_ptr<ngraph::Node> > inputs;
+        for (int i = 0; i < inputNames.size(); ++i)
+        {
+            inputs.push_back(mNodes[inputNames[i]]);
+        }
+        try {
+            addNode(nodeName, std::make_shared<ngraph::opset3::Concat>(inputs, axis));
+        } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+        }
+    }
+    void addConvolution(std::string nodeName, std::string inputName, GenConvParams &gPrms) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s inputName=%s ", __func__, nodeName.c_str(), inputName.c_str());
+        LOGDIMS(gPrms.weightsDims, __func__);
+#endif
+        std::shared_ptr<ngraph::Node> input;
+        try {
+            ngraph::Shape constShape = ngraph::Shape(&gPrms.weightsDims[0], &gPrms.weightsDims[0] + gPrms.weightsDims.size());
+            std::shared_ptr<ngraph::Node> ieWeights = std::make_shared<ngraph::opset3::Constant>(ngraph::element::f32, constShape, gPrms.weightsBuf);
+            if (gPrms.groups != 1)
+            {//GroupConvolution
+                std::vector<size_t> shape(&gPrms.weightsDims[0], &gPrms.weightsDims[0] + 4);
+                shape[0] /= gPrms.groups;
+                shape.insert(shape.begin(), gPrms.groups);
+            
+                auto shapeNode = std::make_shared<ngraph::opset3::Constant>(ngraph::element::i64, ngraph::Shape{shape.size()}, shape.data());
+                ieWeights = std::make_shared<ngraph::opset3::Reshape>(ieWeights, shapeNode, true);
+            }
+            ngraph::op::PadType auto_pad = ngraph::op::PadType::EXPLICIT;
+            if (!std::strcmp(gPrms.pad_type, "explicit"))
+                auto_pad = ngraph::op::PadType::EXPLICIT;
+            else if (!std::strcmp(gPrms.pad_type, "same_upper"))
+                auto_pad = ngraph::op::PadType::SAME_UPPER;
+            else if (!std::strcmp(gPrms.pad_type, "valid"))
+                auto_pad = ngraph::op::PadType::VALID;
+            if(gPrms.groups == 1) {
+                input = std::make_shared<ngraph::opset3::Convolution>(
+                    mNodes[inputName], ieWeights,
+                    ngraph::Strides(gPrms.strides),
+                    ngraph::CoordinateDiff(gPrms.pads_begin),
+                    ngraph::CoordinateDiff(gPrms.pads_end),
+                    ngraph::Strides(gPrms.dilations),
+                    auto_pad);
+            } else {
+                input = std::make_shared<ngraph::opset3::GroupConvolution>(
+                    mNodes[inputName], ieWeights,
+                    ngraph::Strides(gPrms.strides),
+                    ngraph::CoordinateDiff(gPrms.pads_begin),
+                    ngraph::CoordinateDiff(gPrms.pads_end),
+                    ngraph::Strides(gPrms.dilations),
+                    auto_pad);
+            }
+        } catch (const std::exception& ex) {
+                ALOGE("%s Exception !!! %s", __func__, ex.what());
+        }
+        if(gPrms.biasesBuf.size() > 0) {
+#ifdef NNLOG1
+        ALOGD("%s : nodeName=%s has biases size %d", __func__, nodeName.c_str(), gPrms.biasesBuf.size());
+        LOGDIMS(gPrms.biasesDims, __func__);
+#endif
+            std::vector<size_t> shape(input->get_shape().size(), 1);
+            shape[1] = gPrms.biasesDims[0];
+            ngraph::Shape constShape = ngraph::Shape(shape);
+            std::shared_ptr<ngraph::Node> ieBiases = std::make_shared<ngraph::opset3::Constant>(ngraph::element::f32, constShape, gPrms.biasesBuf);
+            addNode(nodeName + "_hasbiases", input);
+            addNode(nodeName, std::make_shared<ngraph::opset3::Add>(input, ieBiases, ngraph::op::AutoBroadcastType::NUMPY));
+        } //while adding a new node connected to this node, inputName passed will be the current nodeName. Hence, the Add node should be mapped to it.
+        else {
+            addNode(nodeName, input);
+        }
+    }
+};  
+}
+}
+}
+}

--- a/intel_nn_hal/graphAPI/create_ngraph.hpp
+++ b/intel_nn_hal/graphAPI/create_ngraph.hpp
@@ -29,19 +29,16 @@ private:
 public:
     InferenceEngine::CNNNetwork generate(std::string xmlPath, std::string binPath) {
 #ifdef NNLOG1
-        ALOGD("%s : Called", __func__);
+        ALOGD("%s : Called with xmlPath %s", __func__, xmlPath.c_str());
 #endif
-        InferenceEngine::CNNNetwork cnn_n;
-        try {
         auto ngraph_function = std::make_shared<ngraph::Function>(mResultNodes, mInputParams);
         InferenceEngine::CNNNetwork cnn = InferenceEngine::CNNNetwork(ngraph_function);
-        //InferenceEngine::ResponseDesc resp;
+        try {
         cnn.serialize(xmlPath, binPath);
-        return cnn;
         } catch (const std::exception& ex) {
                 ALOGE("%s Exception !!! %s", __func__, ex.what());
         }
-        return cnn_n;
+        return cnn;
     }
     void addNode(std::string nodeName, std::shared_ptr<ngraph::Node> node) {
 #ifdef NNLOG1

--- a/intel_nn_hal/service.cpp
+++ b/intel_nn_hal/service.cpp
@@ -38,6 +38,6 @@ int main(int argc, char* argv[]) {
                             deviceType, status);
         joinRpcThreadpool();
     }
-    
+
     return 0;
 }


### PR DESCRIPTION
- Added required ngraph library dependencies to Android.bp
- Enabled following Ngraph operations(with compatibility changes) 
  CONV_2D : Bias is added as an additional Add operation.
  DEPTHWISE_CONV_2D : GroupConvolution with splitting using additional dim.
  RESHAPE : Pre/Post Transpose operations added for expected Reshape(NHWC).
  CONCATENATION : Concatenation axis converted support to 4 dimensions.
  Additional operations used for fused operations: Relu, Clamp.
- Used a map to store the ngraph nodes against the nnhal layer names.
- Converted layers with 3 dimensions to 4 to make a uniform NCHW model.
- Conversion of output to NHWC performed as an added layer in the model.
- Created ngraph::Function from these operations and constructed CNNNetwork.
- Used this CNNNetwork for local(client) inference when needed and also
  to generate IR files to the neuralnetworks directory defined in sepolicy:
  /data/vendor/neuralnetworks
- Used vendor property to configure the ngraph usage:
  vendor.nn.hal.ngraph