### PR TITLE
Move Output handling of nodes into Op Implementations

### DIFF
--- a/ngraph_creator/Android.bp
+++ b/ngraph_creator/Android.bp
@@ -6,13 +6,13 @@ cc_library_static {
     compile_multilib: "64",
 
     srcs: [
-        "src/OperationsBase.cpp",
         "src/OperationsFactory.cpp",
         "src/NgraphNetworkCreator.cpp",
         "src/NgraphNodes.cpp",
         "operations/src/Add.cpp",
         "operations/src/Concat.cpp",
         "operations/src/Reshape.cpp",
+        "operations/src/OperationsBase.cpp",
     ],
 
     header_libs: [

--- a/ngraph_creator/include/NgraphNetworkCreator.hpp
+++ b/ngraph_creator/include/NgraphNetworkCreator.hpp
@@ -15,6 +15,7 @@ private:
 
 public:
     NgraphNetworkCreator(const Model& model, const std::string& plugin);
+    ~NgraphNetworkCreator();
 
     bool validateOperations();
     bool initializeModel();

--- a/ngraph_creator/include/NgraphNodes.hpp
+++ b/ngraph_creator/include/NgraphNodes.hpp
@@ -14,15 +14,16 @@ class NgraphNodes {
 private:
     std::vector<ngraph::Output<ngraph::Node>> mOperationOutputs;
     std::map<int, std::shared_ptr<ngraph::opset3::Parameter>> mInputParamsMap;
-    std::map<int, std::shared_ptr<ngraph::Node>> mResultsMap;
+    std::vector<std::shared_ptr<ngraph::Node>> mResultNodes;
 
 public:
-    NgraphNodes(size_t size);
+    NgraphNodes(size_t operandsSize, size_t resultsSize);
+    ~NgraphNodes();
 
     void addInputParam(size_t index, std::shared_ptr<ngraph::opset3::Parameter> inParam);
     void setOperationOutput(size_t index, ngraph::Output<ngraph::Node> output);
     ngraph::Output<ngraph::Node> getOperationOutput(size_t index);
-    void setResultNode(size_t outputIndex);
+    void setResultNode(size_t outputIndex, std::shared_ptr<ngraph::Node> resultNode);
 
     const std::string& getNodeName(size_t index);
 

--- a/ngraph_creator/include/OperationsFactory.hpp
+++ b/ngraph_creator/include/OperationsFactory.hpp
@@ -14,6 +14,7 @@ private:
 
 public:
     OperationsFactory(const std::string& plugin, std::shared_ptr<NgraphNodes> nodes);
+    ~OperationsFactory();
     std::shared_ptr<OperationsBase> getOperation(const OperationType& type, const Model& model);
 };
 

--- a/ngraph_creator/operations/include/OperationsBase.hpp
+++ b/ngraph_creator/operations/include/OperationsBase.hpp
@@ -16,7 +16,6 @@ namespace nnhal {
 class OperationsBase {
 protected:
     Model mModel;
-    std::shared_ptr<NgraphNodes> mNgraphNodes;
     enum ConversionType { NHWC_NCHW, NCHW_NHWC };
     std::shared_ptr<ngraph::Node> transpose(ConversionType type,
                                             ngraph::Output<ngraph::Node> input);
@@ -25,6 +24,7 @@ protected:
     virtual std::shared_ptr<ngraph::Node> createNodeForPlugin(const Operation& op);
 
 public:
+    static std::shared_ptr<NgraphNodes> mNgraphNodes;
     static std::string sPluginType;
     OperationsBase(const Model& model);
     void setNgraphNodes(std::shared_ptr<NgraphNodes> nodes);

--- a/ngraph_creator/operations/src/Concat.cpp
+++ b/ngraph_creator/operations/src/Concat.cpp
@@ -11,9 +11,8 @@ Concat::Concat(const Model& model) : OperationsBase(model) {}
 bool Concat::validate(const Operation& op) { return true; }
 
 std::shared_ptr<ngraph::Node> Concat::createNode(const Operation& operation) {
-    auto n = operation.inputs.size() - 1;
-    std::vector<uint32_t> axisMap = {2, 3, 1};  // NCHW = axisMap[NHWC]
-    auto axis = axisMap[ParseOperationInput(mModel, operation, n)];
+    auto n = operation.inputs.size() - 1; //0 ~ n-1: The list of n input tensors
+    auto axis = ParseOperationInput(mModel, operation, n); //n: concatenation axis
     std::vector<ngraph::Output<ngraph::Node>> inputs;
     ALOGD("createNode n %d, axis %d", n, axis);
     for (int i = 0; i < n; i++) {
@@ -36,7 +35,6 @@ std::shared_ptr<ngraph::Node> Concat::createNode(const Operation& operation) {
     const auto outputIndex = operation.outputs[0];
     const auto op = mModel.operands[outputIndex];
     if (op.lifetime == OperandLifeTime::MODEL_OUTPUT) {
-        outputNode = transpose(NCHW_NHWC, outputNode);
         mNgraphNodes->setResultNode(outputIndex, outputNode);
     }
     return outputNode;

--- a/ngraph_creator/operations/src/Concat.cpp
+++ b/ngraph_creator/operations/src/Concat.cpp
@@ -31,7 +31,15 @@ std::shared_ptr<ngraph::Node> Concat::createNode(const Operation& operation) {
         inputs.push_back(inputOp);
     }
 
-    return std::make_shared<ngraph::opset3::Concat>(inputs, axis);
+    std::shared_ptr<ngraph::Node> outputNode =
+        std::make_shared<ngraph::opset3::Concat>(inputs, axis);
+    const auto outputIndex = operation.outputs[0];
+    const auto op = mModel.operands[outputIndex];
+    if (op.lifetime == OperandLifeTime::MODEL_OUTPUT) {
+        outputNode = transpose(NCHW_NHWC, outputNode);
+        mNgraphNodes->setResultNode(outputIndex, outputNode);
+    }
+    return outputNode;
 }
 
 }  // namespace nnhal

--- a/ngraph_creator/operations/src/OperationsBase.cpp
+++ b/ngraph_creator/operations/src/OperationsBase.cpp
@@ -6,6 +6,7 @@ namespace neuralnetworks {
 namespace nnhal {
 
 std::string OperationsBase::sPluginType;
+std::shared_ptr<NgraphNodes> OperationsBase::mNgraphNodes;
 
 std::shared_ptr<ngraph::Node> OperationsBase::transpose(ConversionType type,
                                                         ngraph::Output<ngraph::Node> input) {

--- a/ngraph_creator/operations/src/Reshape.cpp
+++ b/ngraph_creator/operations/src/Reshape.cpp
@@ -20,8 +20,6 @@ std::shared_ptr<ngraph::Node> Reshape::createNode(const Operation& operation) {
         inputOperand.lifetime != OperandLifeTime::MODEL_INPUT)
         inputOp = transpose(NCHW_NHWC, inputOp);
 
-    if (outDims.size() == 3) outDims.insert(outDims.begin(), 1);
-
     auto shapeNode = std::make_shared<ngraph::opset3::Constant>(
         ngraph::element::i64, ngraph::Shape{outDims.size()}, outDims.data());
 
@@ -32,8 +30,8 @@ std::shared_ptr<ngraph::Node> Reshape::createNode(const Operation& operation) {
     const auto outputOperand = mModel.operands[outputIndex];
     if (outputOperand.lifetime == OperandLifeTime::MODEL_OUTPUT)
         mNgraphNodes->setResultNode(outputIndex, outputNode);
-    else
-        outputNode = transpose(NHWC_NCHW, outputNode);
+    //else
+        //outputNode = transpose(NHWC_NCHW, outputNode);
     return outputNode;
 }
 }  // namespace nnhal

--- a/ngraph_creator/src/NgraphNetworkCreator.cpp
+++ b/ngraph_creator/src/NgraphNetworkCreator.cpp
@@ -59,7 +59,11 @@ bool NgraphNetworkCreator::initializeModel() {
             ALOGE("initializeModel Failure at type %d", operation.type);
             return false;
         }
-        op->connectOperationToGraph(operation);
+        try {
+            op->connectOperationToGraph(operation);
+        } catch (const std::exception &ex) {
+            ALOGE("%s Exception !!! %s", __func__, ex.what());
+        }
     }
     ALOGD("initializeModel Success");
     return true;
@@ -71,7 +75,13 @@ const std::string& NgraphNetworkCreator::getNodeName(uint32_t index) {
 }
 
 std::shared_ptr<ngraph::Function> NgraphNetworkCreator::generateGraph() {
-    return mNgraphNodes->generateGraph();
+    std::shared_ptr<ngraph::Function> ret;
+    try {
+        ret = mNgraphNodes->generateGraph();
+    } catch (const std::exception &ex) {
+        ALOGE("%s Exception !!! %s", __func__, ex.what());
+    }
+    return ret;
 }
 
 }  // namespace nnhal

--- a/ngraph_creator/src/NgraphNetworkCreator.cpp
+++ b/ngraph_creator/src/NgraphNetworkCreator.cpp
@@ -8,10 +8,13 @@ namespace nnhal {
 
 NgraphNetworkCreator::NgraphNetworkCreator(const Model& model, const std::string& plugin)
     : mModel(model),
-      mNgraphNodes(std::make_shared<NgraphNodes>(mModel.operands.size())),
+      mNgraphNodes(
+          std::make_shared<NgraphNodes>(mModel.operands.size(), mModel.outputIndexes.size())),
       mOpFctryInst(plugin, mNgraphNodes) {
-    ALOGD("NgraphNetworkCreator Constructed");
+    ALOGV("%s Constructed", __func__);
 }
+
+NgraphNetworkCreator::~NgraphNetworkCreator() { ALOGV("%s Destructed", __func__); }
 
 void NgraphNetworkCreator::createInputParams() {
     for (auto i : mModel.inputIndexes) {
@@ -68,10 +71,6 @@ const std::string& NgraphNetworkCreator::getNodeName(uint32_t index) {
 }
 
 std::shared_ptr<ngraph::Function> NgraphNetworkCreator::generateGraph() {
-    for (auto i : mModel.outputIndexes) {
-        ALOGD("setResultNode %d", i);
-        mNgraphNodes->setResultNode(i);
-    }
     return mNgraphNodes->generateGraph();
 }
 

--- a/ngraph_creator/src/NgraphNodes.cpp
+++ b/ngraph_creator/src/NgraphNodes.cpp
@@ -1,10 +1,17 @@
 #include <NgraphNodes.hpp>
+#define LOG_TAG "NgraphNodes"
 
 namespace android {
 namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
-NgraphNodes::NgraphNodes(size_t size) { mOperationOutputs.reserve(size); }
+NgraphNodes::NgraphNodes(size_t operandsSize, size_t resultsSize) {
+    mOperationOutputs.reserve(operandsSize);
+    mResultNodes.reserve(resultsSize);
+    ALOGV("%s Constructed", __func__);
+}
+
+NgraphNodes::~NgraphNodes() { ALOGV("%s Destructed", __func__); }
 
 void NgraphNodes::addInputParam(size_t index, std::shared_ptr<ngraph::opset3::Parameter> inParam) {
     mInputParamsMap[index] = inParam;
@@ -16,36 +23,23 @@ ngraph::Output<ngraph::Node> NgraphNodes::getOperationOutput(size_t index) {
     return mOperationOutputs[index];
 }
 
-void NgraphNodes::setResultNode(size_t outputIndex) {
-    // TODO: Construct this similar to other operations
-    ngraph::AxisVector order = {0, 2, 3, 1};  // NCHW_NHWC
-    const auto order_node =
-        ngraph::opset3::Constant::create(ngraph::element::i64, ngraph::Shape{order.size()}, order);
-    std::shared_ptr<ngraph::Node> resultNode =
-        std::make_shared<ngraph::opset3::Transpose>(mOperationOutputs[outputIndex], order_node);
-    mResultsMap[outputIndex] = resultNode;
+void NgraphNodes::setResultNode(size_t outputIndex, std::shared_ptr<ngraph::Node> resultNode) {
+    ALOGD("setResultNode %d", outputIndex);
+    mResultNodes.push_back(resultNode);
 }
 
 const std::string& NgraphNodes::getNodeName(size_t index) {
-    // The getNodeName is expected to be called only for Inputs and Outputs.
-    // Hence, scan through mInputParamsMap and mResultsMap to identify a valid node name.
-    if (mResultsMap.find(index) != mResultsMap.end()) return mResultsMap[index]->get_name();
-    if (mInputParamsMap.find(index) != mInputParamsMap.end())
-        return mInputParamsMap[index]->get_name();
-    return INVALID_STRING;
+    return mOperationOutputs[index].get_node_shared_ptr()->get_name();
 }
 
 std::shared_ptr<ngraph::Function> NgraphNodes::generateGraph() {
-    std::vector<std::shared_ptr<ngraph::Node>> resultNodes;
-    resultNodes.reserve(mResultsMap.size());
-    for (auto const& temp : mResultsMap) resultNodes.push_back(temp.second);
     // TODO: Remove the Dummy Concat
     // Dummy Concat to join the disconnected graph(ssd_mobilenet Obj Det with only Concat)
-    resultNodes.push_back(std::make_shared<ngraph::opset3::Concat>(resultNodes, 3));
+    mResultNodes.push_back(std::make_shared<ngraph::opset3::Concat>(mResultNodes, 3));
     ngraph::ParameterVector inputParams;
     inputParams.reserve(mInputParamsMap.size());
     for (auto const& temp : mInputParamsMap) inputParams.push_back(temp.second);
-    return std::make_shared<ngraph::Function>(resultNodes, inputParams);
+    return std::make_shared<ngraph::Function>(mResultNodes, inputParams);
 }
 
 }  // namespace nnhal

--- a/ngraph_creator/src/NgraphNodes.cpp
+++ b/ngraph_creator/src/NgraphNodes.cpp
@@ -35,7 +35,7 @@ const std::string& NgraphNodes::getNodeName(size_t index) {
 std::shared_ptr<ngraph::Function> NgraphNodes::generateGraph() {
     // TODO: Remove the Dummy Concat
     // Dummy Concat to join the disconnected graph(ssd_mobilenet Obj Det with only Concat)
-    mResultNodes.push_back(std::make_shared<ngraph::opset3::Concat>(mResultNodes, 3));
+    mResultNodes.push_back(std::make_shared<ngraph::opset3::Concat>(mResultNodes, 2));
     ngraph::ParameterVector inputParams;
     inputParams.reserve(mInputParamsMap.size());
     for (auto const& temp : mInputParamsMap) inputParams.push_back(temp.second);

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -1,13 +1,20 @@
 #include <OperationsFactory.hpp>
+#define LOG_TAG "OperationsFactory"
 
 namespace android {
 namespace hardware {
 namespace neuralnetworks {
 namespace nnhal {
 
-OperationsFactory::OperationsFactory(const std::string& plugin, std::shared_ptr<NgraphNodes> nodes)
-    : mNgraphNodes(nodes) {
+OperationsFactory::OperationsFactory(const std::string& plugin,
+                                     std::shared_ptr<NgraphNodes> nodes) {
     OperationsBase::sPluginType = plugin;
+    OperationsBase::mNgraphNodes = nodes;
+    ALOGV("%s Constructed", __func__);
+}
+OperationsFactory::~OperationsFactory() {
+    OperationsBase::mNgraphNodes.reset();
+    ALOGV("%s Destructed & reset", __func__);
 }
 std::shared_ptr<OperationsBase> OperationsFactory::getOperation(const OperationType& type,
                                                                 const Model& model) {
@@ -27,7 +34,6 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(const OperationT
         default:
             return nullptr;
     }
-    mOperationsMap[type]->setNgraphNodes(mNgraphNodes);
     return mOperationsMap[type];
 }
 


### PR DESCRIPTION
Moved OperationsBase to subdir operations, and made its member
  mNgraphNodes static, to be used across all Op implementations.
Set Result node from the corresponding operation implementations
  based on the outputs' OperandLifeTime(MODEL_OUTPUT).
Use the mOperationOutputs to fetch names from getNodeName API.
Introduced explicit Constructors & Destructors to help debugging.

Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>