### PR TITLE
Fix VTS errors for VtsHalNeuralnetworksV1_2Target

### DIFF
--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define LOG_TAG "BasePreparedModel"
 #include "BasePreparedModel.h"
 
 #include <android-base/logging.h>
@@ -100,7 +99,6 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
     auto plugin = preparedModel->getPlugin();
     auto ngraphNw = preparedModel->getNgraphNwCreator();
     time_point driverEnd, deviceStart, deviceEnd;
-    if (measure == MeasureTiming::YES) deviceStart = now();
     std::vector<RunTimePoolInfo> requestPoolInfos;
     if (!modelInfo->setRunTimePoolInfosFromHidlMemories(request.pools)) {
         notify(callback, ErrorStatus::GENERAL_FAILURE, {}, kNoTiming);
@@ -125,7 +123,9 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
     }
     ALOGD("Run");
 
+    if (measure == MeasureTiming::YES) deviceStart = now();
     plugin->infer();
+    if (measure == MeasureTiming::YES) deviceEnd = now();
 
     for (size_t i = 0; i < request.outputs.size(); i++) {
         auto outIndex = modelInfo->getModelOutputIndex(i);
@@ -170,7 +170,6 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
     auto plugin = preparedModel->getPlugin();
     auto ngraphNw = preparedModel->getNgraphNwCreator();
     time_point driverEnd, deviceStart, deviceEnd;
-    if (measure == MeasureTiming::YES) deviceStart = now();
     std::vector<RunTimePoolInfo> requestPoolInfos;
     if (!modelInfo->setRunTimePoolInfosFromHidlMemories(request.pools)) {
         ALOGE("Failed to set runtime pool info from HIDL memories");
@@ -196,7 +195,9 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
 
     ALOGD("Run");
 
+    if (measure == MeasureTiming::YES) deviceStart = now();
     plugin->infer();
+    if (measure == MeasureTiming::YES) deviceEnd = now();
 
     for (size_t i = 0; i < request.outputs.size(); i++) {
         auto outIndex = modelInfo->getModelOutputIndex(i);

--- a/Driver.cpp
+++ b/Driver.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#define LOG_TAG "Driver"
-
 #include "Driver.h"
 
 #include <android-base/logging.h>
@@ -25,6 +23,8 @@
 #include "GnaPreparedModel.h"
 #include "ModelManager.h"
 #include "ValidateHal.h"
+
+#define LOG_TAG "Driver"
 
 namespace android {
 namespace hardware {

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -504,10 +504,10 @@ bool NnapiModelInfo::isOmittedInput(int operationIndex, uint32_t index) {
 template int NnapiModelInfo::GetConstOperand<int>(unsigned int);
 template unsigned int NnapiModelInfo::GetConstOperand<unsigned int>(unsigned int);
 template float NnapiModelInfo::GetConstOperand<float>(unsigned int);
-template bool NnapiModelInfo::GetConstOperand<bool>(unsigned int);
+template uint8_t NnapiModelInfo::GetConstOperand<uint8_t>(unsigned int);
 template int NnapiModelInfo::GetConstFromBuffer<int>(unsigned char const*, unsigned int);
 template float NnapiModelInfo::GetConstFromBuffer<float>(unsigned char const*, unsigned int);
-template bool NnapiModelInfo::GetConstFromBuffer<bool>(unsigned char const*, unsigned int);
+template uint8_t NnapiModelInfo::GetConstFromBuffer<uint8_t>(unsigned char const*, unsigned int);
 }  // namespace nnhal
 }  // namespace neuralnetworks
 }  // namespace hardware

--- a/cpu/CpuPreparedModel.cpp
+++ b/cpu/CpuPreparedModel.cpp
@@ -1,5 +1,3 @@
-#define LOG_TAG "CpuPreparedModel"
-
 #include "CpuPreparedModel.h"
 #include <android-base/logging.h>
 #include <android/log.h>
@@ -9,6 +7,8 @@
 #include "ExecutionBurstServer.h"
 #include "ValidateHal.h"
 #include "utils.h"
+
+#define LOG_TAG "CpuPreparedModel"
 
 using namespace android::nn;
 
@@ -39,11 +39,16 @@ bool CpuPreparedModel::initialize(const Model& model) {
         ALOGE("%s ngraph generation failed", __func__);
         return false;
     }
-    auto ngraph_net = std::make_shared<InferenceEngine::CNNNetwork>(ngraph_function);
-    ngraph_net->serialize("/data/vendor/neuralnetworks/ngraph_ir.xml",
-                          "/data/vendor/neuralnetworks/ngraph_ir.bin");
-    mPlugin = std::make_shared<IENetwork>(ngraph_net);
-    mPlugin->loadNetwork();
+    try {
+        auto ngraph_net = std::make_shared<InferenceEngine::CNNNetwork>(ngraph_function);
+        ngraph_net->serialize("/data/vendor/neuralnetworks/ngraph_ir.xml",
+                              "/data/vendor/neuralnetworks/ngraph_ir.bin");
+        mPlugin = std::make_shared<IENetwork>(ngraph_net);
+        mPlugin->loadNetwork();
+    } catch (const std::exception& ex) {
+        ALOGE("%s Exception !!! %s", __func__, ex.what());
+        return false;
+    }
 
     ALOGV("Exiting %s", __func__);
     return true;

--- a/ngraph_creator/operations/src/Conv_2d.cpp
+++ b/ngraph_creator/operations/src/Conv_2d.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<ngraph::Node> Conv_2d::createNode() {
                 dilation_width_factor =
                     sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 11);
             case 11:
-                layout = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
+                layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 10);
             default:
                 break;
         }
@@ -136,7 +136,7 @@ std::shared_ptr<ngraph::Node> Conv_2d::createNode() {
                 dilation_width_factor =
                     sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
             case 8:
-                layout = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
+                layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
             default:
                 break;
         }

--- a/ngraph_creator/operations/src/Depthwise_Conv_2d.cpp
+++ b/ngraph_creator/operations/src/Depthwise_Conv_2d.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<ngraph::Node> Depthwise_Conv_2d::createNode() {
             sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 13);
 
         activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
-        layout = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 11);
+        layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 11);
 
         if (layout) useNchw = true;
 
@@ -132,7 +132,7 @@ std::shared_ptr<ngraph::Node> Depthwise_Conv_2d::createNode() {
             sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 10);
 
         activationFn = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 7);
-        layout = sModelInfo->ParseOperationInput<uint32_t>(mNnapiOperationIndex, 8);
+        layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 8);
 
         if (layout) useNchw = true;
 

--- a/ngraph_creator/operations/src/Reduce_All.cpp
+++ b/ngraph_creator/operations/src/Reduce_All.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ngraph::Node> Reduce_All::createNode() {
     // Creating input nodes
     auto input = getInputNode<bool>(0);
     auto reduction_axes = getInputNode<int>(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<bool>(mNnapiOperationIndex, 2);
+    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ngraph::opset3::ReduceLogicalAnd>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/Reduce_Any.cpp
+++ b/ngraph_creator/operations/src/Reduce_Any.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ngraph::Node> Reduce_Any::createNode() {
     // Creating input nodes
     auto input = getInputNode<bool>(0);
     auto reduction_axes = getInputNode<int>(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<bool>(mNnapiOperationIndex, 2);
+    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ngraph::opset3::ReduceLogicalOr>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/Reduce_Min.cpp
+++ b/ngraph_creator/operations/src/Reduce_Min.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ngraph::Node> Reduce_Min::createNode() {
     // Creating input nodes
     auto input = getInputNode<float>(0);
     auto reduction_axes = getInputNode<int>(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<bool>(mNnapiOperationIndex, 2);
+    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode = std::make_shared<ngraph::opset3::ReduceMin>(input, reduction_axes, keep_dims);
 

--- a/ngraph_creator/operations/src/Reduce_Prod.cpp
+++ b/ngraph_creator/operations/src/Reduce_Prod.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ngraph::Node> Reduce_Prod::createNode() {
     // Creating input nodes
     auto input = getInputNode<float>(0);
     auto reduction_axes = getInputNode<int>(1);
-    auto keep_dims = sModelInfo->ParseOperationInput<bool>(mNnapiOperationIndex, 2);
+    auto keep_dims = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 2);
 
     auto outputNode =
         std::make_shared<ngraph::opset3::ReduceProd>(input, reduction_axes, keep_dims);

--- a/ngraph_creator/operations/src/Reshape.cpp
+++ b/ngraph_creator/operations/src/Reshape.cpp
@@ -21,6 +21,12 @@ bool Reshape::validate() {
     if (!checkInputOperandType(1, (int32_t)OperandType::TENSOR_INT32)) {
         return false;
     }
+    const auto& dimsOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    if (!sModelInfo->isOperandLifeTimeConst(dimsOperandIndex)) {
+        // TODO: Support CPU_reshape_all_tensors_as_inputs
+        ALOGE("%s Only Constant dimensions supported now", __func__);
+        return false;
+    }
     ALOGV("%s PASSED", __func__);
     return true;
 }


### PR DESCRIPTION
Avoid crash in Reshape, due to non-Const dimensions.
Fixed multiple vts crashes due to IE errors and incorrect type handling.
Fixed GeneratedTest errors which was due to wrong timeOnDevice value.