### PR TITLE
Fix multiple vts Errors

### DIFF
--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -137,8 +137,6 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
     for (size_t i = 0; i < request.outputs.size(); i++) {
         auto outIndex = modelInfo->getModelOutputIndex(i);
         ALOGI("OutputIndex: %d", outIndex);
-        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i);
-
         const std::string& outputNodeName = ngraphNw->getNodeName(outIndex);
         if (outputNodeName == "") {
             ALOGD("Ignorning output at index(%d), since it is invalid", outIndex);
@@ -147,6 +145,22 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
         ALOGD("Output index: %d layername : %s", outIndex, outputNodeName.c_str());
         auto srcBlob = plugin->getBlob(outputNodeName);
         auto operandType = modelInfo->getOperandType(outIndex);
+        uint32_t expectedLength = srcBlob->byteSize();
+        uint32_t rActualLength = 0;
+        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, rActualLength);
+        auto outDims = srcBlob->getTensorDesc().getDims();
+        if (operandType == OperandType::TENSOR_BOOL8)
+            expectedLength /= 4;  // 8bit expected instead of 32bit
+        if (rActualLength != expectedLength) {
+            ALOGE("%s Invalid length(%d) at outIndex(%d)", __func__, rActualLength, outIndex);
+            // Notify Insufficient Buffer Length to modelInfo
+            modelInfo->updateOutputshapes(i, outDims, false);
+            notify(callback, ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(),
+                   kNoTiming);
+            return;
+        } else {
+            modelInfo->updateOutputshapes(i, outDims);
+        }
         switch (operandType) {
             case OperandType::TENSOR_INT32:
             case OperandType::TENSOR_FLOAT32: {
@@ -225,8 +239,6 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
     for (size_t i = 0; i < request.outputs.size(); i++) {
         auto outIndex = modelInfo->getModelOutputIndex(i);
         ALOGI("OutputIndex: %d", outIndex);
-        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i);
-
         const std::string& outputNodeName = ngraphNw->getNodeName(outIndex);
         if (outputNodeName == "") {
             ALOGD("Ignorning output at index(%d), since it is invalid", outIndex);
@@ -235,6 +247,19 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
         ALOGD("Output index: %d layername : %s", outIndex, outputNodeName.c_str());
         auto srcBlob = plugin->getBlob(outputNodeName);
         auto operandType = modelInfo->getOperandType(outIndex);
+        uint32_t expectedLength = srcBlob->byteSize();
+        uint32_t rActualLength = 0;
+        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, rActualLength);
+        auto outDims = srcBlob->getTensorDesc().getDims();
+        if (operandType == OperandType::TENSOR_BOOL8)
+            expectedLength /= 4;  // 8bit expected instead of 32bit
+        if (rActualLength != expectedLength) {
+            ALOGE("%s Invalid length(%d) at outIndex(%d)", __func__, rActualLength, outIndex);
+            // Notify Insufficient Buffer Length to modelInfo
+            modelInfo->updateOutputshapes(i, outDims, false);
+            return {ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(), kNoTiming};
+        } else
+            modelInfo->updateOutputshapes(i, outDims);
         switch (operandType) {
             case OperandType::TENSOR_INT32:
             case OperandType::TENSOR_FLOAT32: {

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -159,7 +159,7 @@ public:
     T GetConstFromBuffer(const uint8_t* buf, uint32_t len);
 
     Blob::Ptr getBlobFromMemoryPoolIn(const Request& request, uint32_t index);
-    void* getBlobFromMemoryPoolOut(const Request& request, uint32_t index);
+    void* getBlobFromMemoryPoolOut(const Request& request, uint32_t index, uint32_t& rBufferLength);
 
     Model getModel() { return mModel; }
 
@@ -182,6 +182,8 @@ public:
     }
 
     bool isOmittedInput(int operationIndex, uint32_t index);
+    bool updateOutputshapes(size_t outputIndex, std::vector<size_t>& outputShape,
+                            bool isLengthSufficient = true);
 
 private:
     bool initializeRunTimeOperandInfo();

--- a/ngraph_creator/operations/include/OperationsBase.hpp
+++ b/ngraph_creator/operations/include/OperationsBase.hpp
@@ -59,8 +59,8 @@ protected:
 
 public:
     static std::shared_ptr<NnapiModelInfo> sModelInfo;
-    static std::shared_ptr<NgraphNodes> mNgraphNodes;
     static std::string sPluginType;
+    std::shared_ptr<NgraphNodes> mNgraphNodes;
     OperationsBase(int operationIndex);
     void setNgraphNodes(std::shared_ptr<NgraphNodes> nodes);
     virtual bool validate();

--- a/ngraph_creator/operations/src/OperationsBase.cpp
+++ b/ngraph_creator/operations/src/OperationsBase.cpp
@@ -6,7 +6,6 @@ namespace neuralnetworks {
 namespace nnhal {
 
 std::string OperationsBase::sPluginType;
-std::shared_ptr<NgraphNodes> OperationsBase::mNgraphNodes;
 std::shared_ptr<NnapiModelInfo> OperationsBase::sModelInfo;
 
 std::shared_ptr<ngraph::Node> OperationsBase::transpose(ConversionType type,

--- a/ngraph_creator/src/NgraphNetworkCreator.cpp
+++ b/ngraph_creator/src/NgraphNetworkCreator.cpp
@@ -20,7 +20,8 @@ NgraphNetworkCreator::NgraphNetworkCreator(std::shared_ptr<NnapiModelInfo> model
         auto operationNode = mOpFactoryInstance.getOperation(index, nnapiOperationType);
         if (operationNode == nullptr) {
             ALOGV("%s Unsupported Operation type %d", __func__, nnapiOperationType);
-        }
+        } else
+            operationNode->mNgraphNodes = mNgraphNodes;
         mOperationNodes[index] = operationNode;
     }
     ALOGV("%s Constructed", __func__);

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -11,13 +11,9 @@ OperationsFactory::OperationsFactory(const std::string& plugin,
                                      std::shared_ptr<NgraphNodes> nodes) {
     OperationsBase::sPluginType = plugin;
     OperationsBase::sModelInfo = modelInfo;
-    OperationsBase::mNgraphNodes = nodes;
     ALOGV("%s Constructed", __func__);
 }
-OperationsFactory::~OperationsFactory() {
-    OperationsBase::mNgraphNodes.reset();
-    ALOGV("%s Destructed & reset", __func__);
-}
+OperationsFactory::~OperationsFactory() { ALOGV("%s Destructed", __func__); }
 std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
     int operationIndex, const OperationType& operationType) {
     switch (operationType) {


### PR DESCRIPTION
Fix VTS errors for DynamicOutputShapeTest
Add the LSTM scratchBuffer output to Network
Fix Vts error in Squeeze Op for Omitted output
Fix Random crashes observed during VTS execution

VTS Results(with Softmax disabled):

Total Tests       : 29912
PASSED            : 5022
FAILED            : 50
IGNORED           : 24840
