### PR TITLE
Added support for ROI Pooling

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -128,6 +128,7 @@ shared_library("intel_nnhal") {
     "ngraph_creator/operations/src/Relu6.cpp",
     "ngraph_creator/operations/src/Reshape.cpp",
     "ngraph_creator/operations/src/RNN.cpp",
+    "ngraph_creator/operations/src/ROI_Pooling.cpp",
     "ngraph_creator/operations/src/RSQRT.cpp",
     "ngraph_creator/operations/src/Select.cpp",
     "ngraph_creator/operations/src/Sin.cpp",

--- a/ngraph_creator/Android.bp
+++ b/ngraph_creator/Android.bp
@@ -63,6 +63,7 @@ cc_library_static {
         "operations/src/Relu6.cpp",
         "operations/src/Reshape.cpp",
         "operations/src/RNN.cpp",
+        "operations/src/ROI_Pooling.cpp",
         "operations/src/RSQRT.cpp",
         "operations/src/Select.cpp",
         "operations/src/Softmax.cpp",

--- a/ngraph_creator/include/OperationsFactory.hpp
+++ b/ngraph_creator/include/OperationsFactory.hpp
@@ -54,6 +54,7 @@
 #include <Relu1.hpp>
 #include <Relu6.hpp>
 #include <Reshape.hpp>
+#include <ROI_Pooling.hpp>
 #include <SQRT.hpp>
 #include <Select.hpp>
 #include <Sin.hpp>

--- a/ngraph_creator/include/OperationsFactory.hpp
+++ b/ngraph_creator/include/OperationsFactory.hpp
@@ -43,6 +43,7 @@
 #include <Pow.hpp>
 #include <Quantize.hpp>
 #include <RNN.hpp>
+#include <ROI_Pooling.hpp>
 #include <RSQRT.hpp>
 #include <Reduce_All.hpp>
 #include <Reduce_Any.hpp>
@@ -54,7 +55,6 @@
 #include <Relu1.hpp>
 #include <Relu6.hpp>
 #include <Reshape.hpp>
-#include <ROI_Pooling.hpp>
 #include <SQRT.hpp>
 #include <Select.hpp>
 #include <Sin.hpp>

--- a/ngraph_creator/operations/include/ROI_Pooling.hpp
+++ b/ngraph_creator/operations/include/ROI_Pooling.hpp
@@ -18,4 +18,3 @@ public:
 }  // namespace neuralnetworks
 }  // namespace hardware
 }  // namespace android
-

--- a/ngraph_creator/operations/include/ROI_Pooling.hpp
+++ b/ngraph_creator/operations/include/ROI_Pooling.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <OperationsBase.hpp>
+
+namespace android {
+namespace hardware {
+namespace neuralnetworks {
+namespace nnhal {
+
+class ROI_Pooling : public OperationsBase {
+public:
+    ROI_Pooling(int operationIndex);
+    bool validate() override;
+    std::shared_ptr<ngraph::Node> createNode() override;
+};
+
+}  // namespace nnhal
+}  // namespace neuralnetworks
+}  // namespace hardware
+}  // namespace android
+

--- a/ngraph_creator/operations/src/ROI_Pooling.cpp
+++ b/ngraph_creator/operations/src/ROI_Pooling.cpp
@@ -1,0 +1,121 @@
+//#define LOG_NDEBUG 0
+#include <ROI_Pooling.hpp>
+#define LOG_TAG "ROI_Pooling"
+
+namespace android {
+namespace hardware {
+namespace neuralnetworks {
+namespace nnhal {
+
+ROI_Pooling::ROI_Pooling(int operationIndex) : OperationsBase(operationIndex) {
+    mDefaultOutputIndex = sModelInfo->getOperationOutput(mNnapiOperationIndex, 0);
+}
+
+bool ROI_Pooling::validate() {
+
+    ALOGV("%s Entering", __func__);
+
+    // Check Output type
+    if (!checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32)) {
+        return false;
+    }
+
+    // Check Input Type
+    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32))
+        return false;
+    if (!checkInputOperandType(1, (int32_t)OperandType::TENSOR_FLOAT32))
+        return false;
+
+    if (!checkInputOperandType(2, (int32_t)OperandType::TENSOR_INT32)) return false;
+    if (!checkInputOperandType(3, (int32_t)OperandType::INT32)) return false;
+    if (!checkInputOperandType(4, (int32_t)OperandType::INT32)) return false;
+    if (!checkInputOperandType(5, (int32_t)OperandType::FLOAT32)) return false;
+    if (!checkInputOperandType(6, (int32_t)OperandType::FLOAT32)) return false;
+    if (!checkInputOperandType(7, (int32_t)OperandType::BOOL)) return false;
+
+    //TODO: Need to rectify the test cases. Fails with different height_ratio and width_ratio values
+    auto height_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5);                                                                                   
+    auto width_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6);
+    if(height_ratio != width_ratio)
+    {
+        ALOGE("%s: Ratio of Height and Ratio of Width from orginal image to feature map must be same for ROI Pooling. Got %f and %f",__func__,height_ratio,width_ratio);
+        return false;
+    }
+
+    ALOGV("%s PASSED", __func__);
+    return true;
+}
+
+std::shared_ptr<ngraph::Node> ROI_Pooling::createNode() {
+
+    ALOGV("%s Entering", __func__);
+
+    bool useNchw = false;
+
+    //Read inputs
+    auto feat_maps     = getInputNode(0); //4D tensor
+    auto output_height = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 3); //height of the output tensor
+    auto output_width  = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 4); //width of the output tensor
+    auto height_ratio  = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5); //ratio from the height of original image to the height of feature map.                                                                                   
+    auto width_ratio   = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6); //ratio from the width of original image to the height of feature map.
+    auto layout        = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7); 
+    
+    if (layout) useNchw = true;
+
+    auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
+    if (mNgraphNodes->isForcedNchw(inputIndex)) {
+        if (useNchw) {
+            ALOGI("%s Forced NCHW done already but NCHW flag set at operationIndex %d", __func__,
+                  mNnapiOperationIndex);
+            feat_maps = transpose(NCHW_NHWC, feat_maps);
+            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, false);
+        } else {
+            // Already forced NCHW, propogate the flag
+            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, true);
+        }
+    } else if (!useNchw) {  // No conversion needed if useNchw set
+        feat_maps = transpose(NHWC_NCHW, feat_maps);
+        mNgraphNodes->setForcedNchw(mDefaultOutputIndex, true);
+        ALOGD("%s Forced NCHW conversion at operationIndex %d", __func__, mNnapiOperationIndex);
+    }
+
+    auto output_size = ngraph::Shape{(size_t)output_height,(size_t)output_width};
+    float spatial_scale = 1.0/(height_ratio);
+    
+    // Concat batch index of shape [num_rois] and rois shape [num_rois, 4]
+    // to create 2-D Tensor of shape [num_rois, 5] => bi,x1,y1,x2,y2
+    std::vector<ngraph::Output<ngraph::Node>> inputs;
+    auto n = 2;                                                   
+    auto axis = 1;
+    // add bi node to inputs for concat
+    const auto& biOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);      
+    auto bi_vec = sModelInfo->GetConstVecOperand<int32_t>(biOperandIndex);
+    const auto bi_node = createConstNode(ngraph::element::f32, ngraph::Shape{bi_vec.size(),1}, bi_vec);
+    inputs.push_back(bi_node);
+    // add rois node to inputs for concat
+    auto inputIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto inputOp = mNgraphNodes->getOperationOutput(inputIndex1);
+    inputs.push_back(inputOp);
+
+    std::shared_ptr<ngraph::Node> roiNode = std::make_shared<ngraph::opset3::Concat>(inputs, axis);
+    ALOGI("%s Concatinated roi_node created", __func__);
+  
+    std::shared_ptr<ngraph::Node> outputNode = std::make_shared<ngraph::opset3::ROIPooling>(feat_maps, roiNode,output_size,spatial_scale);
+
+    const auto outputLifetime = sModelInfo->getOperandLifetime(mDefaultOutputIndex);
+    if (outputLifetime == OperandLifeTime::MODEL_OUTPUT) {
+        if (!useNchw) {
+            outputNode = transpose(NCHW_NHWC, outputNode);
+            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, false);
+        }
+        addResultNode(mDefaultOutputIndex, outputNode);
+    }
+
+    ALOGV("%s PASSED", __func__);
+
+    return outputNode;
+}
+}  // namespace nnhal
+}  // namespace neuralnetworks
+}  // namespace hardware
+}  // namespace android

--- a/ngraph_creator/operations/src/ROI_Pooling.cpp
+++ b/ngraph_creator/operations/src/ROI_Pooling.cpp
@@ -12,33 +12,33 @@ ROI_Pooling::ROI_Pooling(int operationIndex) : OperationsBase(operationIndex) {
 }
 
 bool ROI_Pooling::validate() {
-
     ALOGV("%s Entering", __func__);
 
     // Check Output type
     if (!checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32)) {
+        ALOGE("%s Output operand 0 is not of type FP32. Unsupported operation", __func__);
         return false;
     }
 
     // Check Input Type
-    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32))
+    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32)) {
+        ALOGE("%s Input operand 0 is not of type FP32. Unsupported operation", __func__);
         return false;
-    if (!checkInputOperandType(1, (int32_t)OperandType::TENSOR_FLOAT32))
+    }
+    if (!checkInputOperandType(1, (int32_t)OperandType::TENSOR_FLOAT32)) {
+        ALOGE("%s Input operand 1 is not of type FP32. Unsupported operation", __func__);
         return false;
+    }
 
-    if (!checkInputOperandType(2, (int32_t)OperandType::TENSOR_INT32)) return false;
-    if (!checkInputOperandType(3, (int32_t)OperandType::INT32)) return false;
-    if (!checkInputOperandType(4, (int32_t)OperandType::INT32)) return false;
-    if (!checkInputOperandType(5, (int32_t)OperandType::FLOAT32)) return false;
-    if (!checkInputOperandType(6, (int32_t)OperandType::FLOAT32)) return false;
-    if (!checkInputOperandType(7, (int32_t)OperandType::BOOL)) return false;
-
-    //TODO: Need to rectify the test cases. Fails with different height_ratio and width_ratio values
-    auto height_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5);                                                                                   
+    // TODO: support for different height_ratio and width_ratio
+    // values
+    auto height_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5);
     auto width_ratio = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6);
-    if(height_ratio != width_ratio)
-    {
-        ALOGE("%s: Ratio of Height and Ratio of Width from orginal image to feature map must be same for ROI Pooling. Got %f and %f",__func__,height_ratio,width_ratio);
+    if (height_ratio != width_ratio) {
+        ALOGE(
+            "%s: Ratio of Height and Ratio of Width from orginal image to feature map must be same "
+            "for ROI Pooling. Got %f and %f",
+            __func__, height_ratio, width_ratio);
         return false;
     }
 
@@ -47,69 +47,54 @@ bool ROI_Pooling::validate() {
 }
 
 std::shared_ptr<ngraph::Node> ROI_Pooling::createNode() {
-
     ALOGV("%s Entering", __func__);
 
     bool useNchw = false;
 
-    //Read inputs
-    auto feat_maps     = getInputNode(0); //4D tensor
-    auto output_height = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 3); //height of the output tensor
-    auto output_width  = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 4); //width of the output tensor
-    auto height_ratio  = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 5); //ratio from the height of original image to the height of feature map.                                                                                   
-    auto width_ratio   = sModelInfo->ParseOperationInput<float>(mNnapiOperationIndex, 6); //ratio from the width of original image to the height of feature map.
-    auto layout        = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7); 
-    
+    // Read inputs
+    auto feat_maps = getInputNode(0);  // 4D tensor
+    auto output_height = sModelInfo->ParseOperationInput<int32_t>(
+        mNnapiOperationIndex, 3);  // height of the output tensor
+    auto output_width = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex,
+                                                                 4);  // width of the output tensor
+    auto height_ratio = sModelInfo->ParseOperationInput<float>(
+        mNnapiOperationIndex,
+        5);  // ratio from the height of original image to the height of feature map.
+    auto width_ratio = sModelInfo->ParseOperationInput<float>(
+        mNnapiOperationIndex,
+        6);  // ratio from the width of original image to the height of feature map.
+    auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 7);
+
     if (layout) useNchw = true;
 
-    auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    if (mNgraphNodes->isForcedNchw(inputIndex)) {
-        if (useNchw) {
-            ALOGI("%s Forced NCHW done already but NCHW flag set at operationIndex %d", __func__,
-                  mNnapiOperationIndex);
-            feat_maps = transpose(NCHW_NHWC, feat_maps);
-            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, false);
-        } else {
-            // Already forced NCHW, propogate the flag
-            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, true);
-        }
-    } else if (!useNchw) {  // No conversion needed if useNchw set
+    if (!useNchw)  // No conversion needed if useNchw set
         feat_maps = transpose(NHWC_NCHW, feat_maps);
-        mNgraphNodes->setForcedNchw(mDefaultOutputIndex, true);
-        ALOGD("%s Forced NCHW conversion at operationIndex %d", __func__, mNnapiOperationIndex);
-    }
 
-    auto output_size = ngraph::Shape{(size_t)output_height,(size_t)output_width};
-    float spatial_scale = 1.0/(height_ratio);
-    
-    // Concat batch index of shape [num_rois] and rois shape [num_rois, 4]
-    // to create 2-D Tensor of shape [num_rois, 5] => bi,x1,y1,x2,y2
+    auto output_size = ngraph::Shape{(size_t)output_height, (size_t)output_width};
+    float spatial_scale = 1.0 / (height_ratio);
+
+    // Concat batch index of shape[num_rois] and rois shape[num_rois, 4]
+    // to create 2-D Tensor of shape[num_rois, 5] => bi,x1,y1,x2,y2
     std::vector<ngraph::Output<ngraph::Node>> inputs;
-    auto n = 2;                                                   
     auto axis = 1;
     // add bi node to inputs for concat
-    const auto& biOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);      
+    const auto& biOperandIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
     auto bi_vec = sModelInfo->GetConstVecOperand<int32_t>(biOperandIndex);
-    const auto bi_node = createConstNode(ngraph::element::f32, ngraph::Shape{bi_vec.size(),1}, bi_vec);
+    const auto bi_node =
+        createConstNode(ngraph::element::f32, ngraph::Shape{bi_vec.size(), 1}, bi_vec);
     inputs.push_back(bi_node);
     // add rois node to inputs for concat
-    auto inputIndex1 = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
-    auto inputOp = mNgraphNodes->getOperationOutput(inputIndex1);
+    auto inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
+    auto inputOp = mNgraphNodes->getOperationOutput(inputIndex);
     inputs.push_back(inputOp);
 
     std::shared_ptr<ngraph::Node> roiNode = std::make_shared<ngraph::opset3::Concat>(inputs, axis);
     ALOGI("%s Concatinated roi_node created", __func__);
-  
-    std::shared_ptr<ngraph::Node> outputNode = std::make_shared<ngraph::opset3::ROIPooling>(feat_maps, roiNode,output_size,spatial_scale);
 
-    const auto outputLifetime = sModelInfo->getOperandLifetime(mDefaultOutputIndex);
-    if (outputLifetime == OperandLifeTime::MODEL_OUTPUT) {
-        if (!useNchw) {
-            outputNode = transpose(NCHW_NHWC, outputNode);
-            mNgraphNodes->setForcedNchw(mDefaultOutputIndex, false);
-        }
-        addResultNode(mDefaultOutputIndex, outputNode);
-    }
+    std::shared_ptr<ngraph::Node> outputNode = std::make_shared<ngraph::opset3::ROIPooling>(
+        feat_maps, roiNode, output_size, spatial_scale);
+
+    if (!useNchw) outputNode = transpose(NCHW_NHWC, outputNode);
 
     ALOGV("%s PASSED", __func__);
 

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -123,7 +123,7 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<Reshape>(operationIndex);
         case OperationType::RNN:
             return std::make_shared<RNN>(operationIndex);
-		case OperationType::ROI_POOLING:
+        case OperationType::ROI_POOLING:
             return std::make_shared<ROI_Pooling>(operationIndex);
         case OperationType::RSQRT:
             return std::make_shared<RSQRT>(operationIndex);

--- a/ngraph_creator/src/OperationsFactory.cpp
+++ b/ngraph_creator/src/OperationsFactory.cpp
@@ -123,6 +123,8 @@ std::shared_ptr<OperationsBase> OperationsFactory::getOperation(
             return std::make_shared<Reshape>(operationIndex);
         case OperationType::RNN:
             return std::make_shared<RNN>(operationIndex);
+		case OperationType::ROI_POOLING:
+            return std::make_shared<ROI_Pooling>(operationIndex);
         case OperationType::RSQRT:
             return std::make_shared<RSQRT>(operationIndex);
         case OperationType::SELECT:


### PR DESCRIPTION
Added support for ROI Pooling for FP32

VTS
[----------] Global test environment tear-down
[==========] 120 tests from 3 test suites ran. (414 ms total)
[  PASSED  ] 40 tests.
[  SKIPPED ] 80 tests.

CTS
[----------] Global test environment tear-down
[==========] 366 tests from 5 test suites ran. (5773 ms total)
[  PASSED  ] 366 tests.
