### PR TITLE
Reduce memory usage

### DIFF
--- a/intel_nn_hal/Dequantize.h
+++ b/intel_nn_hal/Dequantize.h
@@ -62,6 +62,10 @@ class DequantizeOp : public BaseOp {
         }
 
         bool  run() {
+            if (dummyOp_) {
+                output = (void*)inputDataPtr;
+                return true;
+            }
             const T* inputBuf = reinterpret_cast<const T*>(inputDataPtr);
             deq_output = new float[inputLen];
 
@@ -74,30 +78,16 @@ class DequantizeOp : public BaseOp {
             return true;
         }
 
-        float*  run(const uint8_t* inputData, const uint32_t len) {
-            deq_output = new float[len];
-
-            int32_t value;
-            const T* inputBuf = reinterpret_cast<const T*>(inputData);
-            for (int i = 0; i < len; ++i) {
-                value = *(inputBuf + i);
-                deq_output[i] = static_cast<float>(scale * (value - zeroPoint));
-            }
-            output = deq_output;
-
-            return deq_output;
-        }
-
         std::string getLayerName() { return layerName; }
 
         void cleanup() {
             if (deq_output && !dummyOp_)
-                delete deq_output;
+                delete[] deq_output;
         }
 
         ~DequantizeOp() {
             if (deq_output && !dummyOp_)
-                delete deq_output;
+                delete[] deq_output;
         }
 };
 

--- a/intel_nn_hal/GnaPreparedModel.h
+++ b/intel_nn_hal/GnaPreparedModel.h
@@ -72,7 +72,7 @@ class GnaPreparedModel : public PreparedModel {
     IRBuilder::ModelBuilder* mBuilderModel;
     GnaNetwork* gnaPluginPtr;
     std::vector<IRBlob::Ptr> mModelIRBlobs; /*intermediate IRBlobs to be deallocated after network is loaded into the Plugin */
-
+    std::map<uint32_t, bool> dummyOpMap;
     std::vector<OpContainer*> mNwManager;
 
     bool isDecoderNw = false;


### PR DESCRIPTION
IRBlobs are created using std::make_shared but VmRSS
increases if the IRBlob is not deallocated using deallocate()

TEST:sudo python2 scripts/run_asr_eval.py --disable_services
    --audio_files_proto=configs/file_lists/testdata-small-fi
    les.ascii_proto --soda_driver_path=libsoda_chromeos_keyless-tigerlake.so
    --soda_lp_dir=soda/redense_medium_quant/
     CTS/VTS tests