### PR TITLE
[WIP] [DO NOT MERGE] Change the dequantize node graph

### DIFF
--- a/ngraph_creator/operations/src/FullyConnected.cpp
+++ b/ngraph_creator/operations/src/FullyConnected.cpp
@@ -17,22 +17,13 @@ bool FullyConnected::validate() {
     auto input2 = getInputOperand(2);
     auto output0 = getOutputOperand(0);
 
-    if (input0.type != OperandType::TENSOR_FLOAT32) {
-        ALOGD("%s: Input operand 0 is not of type FP32. Unsupported operation", __func__);
-        return false;
-    }
-
-    if (output0.type != OperandType::TENSOR_FLOAT32) {
-        ALOGD("%s Output operand 0 is not of type FP32 / I32. Unsupported operation", __func__);
-        return false;
-    }
-
+    //TODO: Verify TENSOR_QUANT8_ASYMM_SIGNED with 1.3 nnhal driver
     // Input 2 should be of same type of Input 0
     if (input0.type != input2.type) {
         return false;
     }
 
-    if (input0.dimensions[0] == 0) {
+    if (!isZeroSizedInput(0)) {
         ALOGE("%s Batch size of 0 is not supported", __func__);
         return false;
     }

--- a/ngraph_creator/operations/src/Grouped_Conv_2d.cpp
+++ b/ngraph_creator/operations/src/Grouped_Conv_2d.cpp
@@ -162,9 +162,6 @@ std::shared_ptr<ngraph::Node> Grouped_Conv_2d::createNode() {
     }
 
     std::shared_ptr<ngraph::Node> inputNode, filterNode, biasNode;
-
-    const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    const auto& filterIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     const auto& biasIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
 
     inputNode = getInputNode(0);

--- a/ngraph_creator/operations/src/ROI_Align.cpp
+++ b/ngraph_creator/operations/src/ROI_Align.cpp
@@ -84,11 +84,13 @@ std::shared_ptr<ngraph::Node> ROI_Align::createNode() {
     auto height_ratio = sModelInfo->ParseOperationInput<float>(
         mNnapiOperationIndex,
         5);  // ratio from the height of original image to the height of feature map.
-    auto width_ratio = sModelInfo->ParseOperationInput<float>(
-        mNnapiOperationIndex,
-        6);  // ratio from the width of original image to the height of feature map.
+    //TODO: Since same ratio is applied on height and width, commenting
+    //the width_ratio and sampling_pts_w currently
+    //auto width_ratio = sModelInfo->ParseOperationInput<float>(
+    //    mNnapiOperationIndex,
+    //    6);  // ratio from the width of original image to the height of feature map.
     auto sampling_pts_h = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 7);
-    auto sampling_pts_w = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 8);
+    //auto sampling_pts_w = sModelInfo->ParseOperationInput<int32_t>(mNnapiOperationIndex, 8);
     auto layout = sModelInfo->ParseOperationInput<uint8_t>(mNnapiOperationIndex, 9);
 
     if (layout) useNchw = true;


### PR DESCRIPTION
While constructing the dequantize graph use conversion to FP32
instead of INT32.

Signed-off-by: P Raviraj Sitaram <raviraj.p.sitaram@intel.com>