### PR TITLE
Change the dequantize node graph 

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -167,25 +167,25 @@ shared_library("intel_nnhal") {
     "intel_nn_hal/graphAPI",
     "intel_nn_hal/graphAPI/builderLayerNorm",
     "intel_nn_hal/dl",
-    "../intel-openvino-dev/inference-engine/src/inference_engine",
-    "../intel-openvino-dev/inference-engine/thirdparty/pugixml/src",
     "../intel-openvino-dev/inference-engine/include",
+    "../intel-openvino-dev/inference-engine/include/cldnn",
     "../intel-openvino-dev/inference-engine/include/cpp",
     "../intel-openvino-dev/inference-engine/include/details",
     "../intel-openvino-dev/inference-engine/include/details/os",
-    "../intel-openvino-dev/inference-engine/include/cldnn",
     "../intel-openvino-dev/inference-engine/include/gna",
     "../intel-openvino-dev/inference-engine/include/hetero",
     "../intel-openvino-dev/inference-engine/include/mkldnn",
     "../intel-openvino-dev/inference-engine/include/openvx",
     "../intel-openvino-dev/inference-engine/include/vpu",
-    "../intel-openvino-dev/inference-engine/src/inference_engine",
     "../intel-openvino-dev/inference-engine/src/dumper",
+    "../intel-openvino-dev/inference-engine/src/inference_engine",
     "../intel-openvino-dev/inference-engine/src/inference_engine/cpp_interfaces",
     "../intel-openvino-dev/inference-engine/src/inference_engine/cpp_interfaces/base",
     "../intel-openvino-dev/inference-engine/src/inference_engine/cpp_interfaces/impl",
     "../intel-openvino-dev/inference-engine/src/inference_engine/cpp_interfaces/interface",
-    "../intel-openvino-dev/inference-engine/thirdparty/pugixml/src/",
+    "../intel-openvino-dev/inference-engine/src/inference_engine/include/ie",
+    "../intel-openvino-dev/inference-engine/src/inference_engine/include/ie/cpp",
+    "../intel-openvino-dev/thirdparty/pugixml/src/",
     "../intel-openvino-dev/ngraph/core/include",
   ]
   libs = [
@@ -227,9 +227,9 @@ static_library("pugixml") {
     "-DIMPLEMENT_INFERENCE_ENGINE_API",
   ]
   sources = [
-    "../intel-openvino-dev/inference-engine/thirdparty/pugixml/src/pugixml.cpp"
+    "../intel-openvino-dev/thirdparty/pugixml/src/pugixml.cpp"
   ]
   include_dirs = [
-   "../intel-openvino-dev/inference-engine/thirdparty/pugixml/src",
+   "../intel-openvino-dev/thirdparty/pugixml/src",
   ]
 }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -194,9 +194,10 @@ shared_library("intel_nnhal") {
     "nnapi-support",
     "ngraph",
     "inference_engine",
-    "nn-common", 
+    "nn-common",
     "ssl",
-    "crypto"
+    "crypto",
+    "MKLDNNPlugin"
   ]
   lib_dirs = [
     "${sysroot}/usr/local/deployment_tools/inference_engine/lib/intel64/",

--- a/BasePreparedModel.cpp
+++ b/BasePreparedModel.cpp
@@ -150,7 +150,7 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
             float* dest = destBlob->buffer().as<float*>();
             _Float16* src = (_Float16*)srcPtr;
 
-            for (auto i = 0; i < len / 2; i++) {
+            for (unsigned int i = 0; i < len / 2; i++) {
                 dest[i] = src[i];
             }
         } else {
@@ -181,10 +181,10 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
         ALOGD("Output index: %d layername : %s", outIndex, outputNodeName.c_str());
         auto srcBlob = plugin->getBlob(outputNodeName);
         auto operandType = modelInfo->getOperandType(outIndex);
-        uint32_t expectedLength = srcBlob->byteSize();
-        uint32_t rActualLength = 0;
-        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, rActualLength);
-        auto outDims = srcBlob->getTensorDesc().getDims();
+        uint32_t actualLength = srcBlob->byteSize();
+        uint32_t expectedLength = 0;
+        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, expectedLength);
+        auto outputBlobDims = srcBlob->getTensorDesc().getDims();
 
         ALOGD("output precision: %d", static_cast<int>(srcBlob->getTensorDesc().getPrecision()));
 
@@ -193,27 +193,40 @@ void asyncExecute(const Request& request, MeasureTiming measure, BasePreparedMod
             case OperandType::TENSOR_QUANT8_ASYMM:
             case OperandType::TENSOR_QUANT8_SYMM:
             case OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL:
-                expectedLength /= 4;
+                actualLength /= 4;
                 break;
             case OperandType::TENSOR_FLOAT16:
-                expectedLength /= 2;
+                actualLength /= 2;
                 break;
             default:
                 ALOGV("Operand type is 4 bytes !!");
                 break;
         }
 
-        if (rActualLength != expectedLength) {
+        bool outputSizeMismatch = false;
+        if (actualLength != expectedLength) {
             ALOGE("%s Invalid length at outIndex(%d) Actual:%d Expected:%d", __func__, outIndex,
-                  rActualLength, expectedLength);
-            // Notify Insufficient Buffer Length to modelInfo
-            modelInfo->updateOutputshapes(i, outDims, false);
+                  actualLength, expectedLength);
+            outputSizeMismatch = true;
+        }
+
+        // TODO: bug identified with OV2021.4 where for Pad operation, if the output dimensions is 1
+        // output dimension is coming as 0
+        if ((outputBlobDims.size() == 0) && (actualLength != 0)) {
+            std::vector<size_t> rdims = {1};
+            modelInfo->updateOutputshapes(i, rdims, outputSizeMismatch ? false : true);
+        } else
+            modelInfo->updateOutputshapes(i, outputBlobDims, outputSizeMismatch ? false : true);
+
+        if (outputSizeMismatch) {
+            ALOGE(
+                "Mismatch in actual and exepcted output sizes. Return with "
+                "OUTPUT_INSUFFICIENT_SIZE error");
             notify(callback, ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(),
                    kNoTiming);
             return;
-        } else {
-            modelInfo->updateOutputshapes(i, outDims);
         }
+
         switch (operandType) {
             case OperandType::TENSOR_INT32:
             case OperandType::TENSOR_FLOAT32: {
@@ -294,7 +307,7 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
             float* dest = destBlob->buffer().as<float*>();
             _Float16* src = (_Float16*)srcPtr;
 
-            for (auto i = 0; i < len / 2; i++) {
+            for (unsigned int i = 0; i < len / 2; i++) {
                 dest[i] = src[i];
             }
         } else {
@@ -325,10 +338,10 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
         ALOGD("Output index: %d layername : %s", outIndex, outputNodeName.c_str());
         auto srcBlob = plugin->getBlob(outputNodeName);
         auto operandType = modelInfo->getOperandType(outIndex);
-        uint32_t expectedLength = srcBlob->byteSize();
-        uint32_t rActualLength = 0;
-        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, rActualLength);
-        auto outDims = srcBlob->getTensorDesc().getDims();
+        uint32_t actualLength = srcBlob->byteSize();
+        uint32_t expectedLength = 0;
+        void* destPtr = modelInfo->getBlobFromMemoryPoolOut(request, i, expectedLength);
+        auto outputBlobDims = srcBlob->getTensorDesc().getDims();
 
         ALOGD("output precision: %d", static_cast<int>(srcBlob->getTensorDesc().getPrecision()));
 
@@ -337,22 +350,38 @@ static std::tuple<ErrorStatus, hidl_vec<V1_2::OutputShape>, Timing> executeSynch
             case OperandType::TENSOR_QUANT8_ASYMM:
             case OperandType::TENSOR_QUANT8_SYMM:
             case OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL:
-                expectedLength /= 4;
+                actualLength /= 4;
                 break;
             case OperandType::TENSOR_FLOAT16:
-                expectedLength /= 2;
+                actualLength /= 2;
                 break;
             default:
                 ALOGV("Operand type is 4 bytes !!");
                 break;
         }
-        if (rActualLength != expectedLength) {
-            ALOGE("%s Invalid length(%d) at outIndex(%d)", __func__, rActualLength, outIndex);
-            // Notify Insufficient Buffer Length to modelInfo
-            modelInfo->updateOutputshapes(i, outDims, false);
-            return {ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(), kNoTiming};
+
+        bool outputSizeMismatch = false;
+        if (actualLength != expectedLength) {
+            ALOGE("%s Invalid length at outIndex(%d) Actual:%d Expected:%d", __func__, outIndex,
+                  actualLength, expectedLength);
+            outputSizeMismatch = true;
+        }
+
+        // TODO: bug identified with OV2021.4 where for Pad operation, if the output dimensions is 1
+        // output dimension is coming as 0
+        if ((outputBlobDims.size() == 0) && (actualLength != 0)) {
+            std::vector<size_t> rdims = {1};
+            modelInfo->updateOutputshapes(i, rdims, outputSizeMismatch ? false : true);
         } else
-            modelInfo->updateOutputshapes(i, outDims);
+            modelInfo->updateOutputshapes(i, outputBlobDims, outputSizeMismatch ? false : true);
+
+        if (outputSizeMismatch) {
+            ALOGE(
+                "Mismatch in actual and exepcted output sizes. Return with "
+                "OUTPUT_INSUFFICIENT_SIZE error");
+            return {ErrorStatus::OUTPUT_INSUFFICIENT_SIZE, modelInfo->getOutputShapes(), kNoTiming};
+        }
+
         switch (operandType) {
             case OperandType::TENSOR_INT32:
             case OperandType::TENSOR_FLOAT32: {

--- a/IENetwork.cpp
+++ b/IENetwork.cpp
@@ -30,23 +30,6 @@ bool IENetwork::loadNetwork() {
 
         mInputInfo = mNetwork->getInputsInfo();
         mOutputInfo = mNetwork->getOutputsInfo();
-
-        //#ifdef NN_DEBUG
-        for (auto input : mInputInfo) {
-            auto dims = input.second->getTensorDesc().getDims();
-            for (auto i : dims) {
-                ALOGI(" Dimes : %lu", i);
-            }
-            ALOGI("Name: %s ", input.first.c_str());
-        }
-        for (auto output : mOutputInfo) {
-            auto dims = output.second->getTensorDesc().getDims();
-            for (auto i : dims) {
-                ALOGI(" Dimes : %lu", i);
-            }
-            ALOGI("Name: %s ", output.first.c_str());
-        }
-        //#endif
     } else {
         ALOGE("Invalid Network pointer");
         return false;

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -12,7 +12,6 @@ bool NnapiModelInfo::updateOutputshapes(size_t outputIndex, std::vector<size_t>&
     auto& outputShapeDims = mOutputShapes[outputIndex].dimensions;
     mOutputShapes[outputIndex].isSufficient = isLengthSufficient;
     if (outputDims.size() < outputShapeDims.size()) {
-        ALOGE("%s Output size mismatch at index(%zu)", __func__, outputIndex);
         return false;
     }
     for (size_t i = 0; i < outputShapeDims.size(); i++) {

--- a/cpu/CpuPreparedModel.cpp
+++ b/cpu/CpuPreparedModel.cpp
@@ -45,7 +45,7 @@ bool CpuPreparedModel::initialize() {
         cnnNetworkPtr->serialize("/data/vendor/neuralnetworks/ngraph_ir.xml",
                                  "/data/vendor/neuralnetworks/ngraph_ir.bin");
 #else
-        ngraph_net->serialize("/tmp/ngraph_ir.xml", "/tmp/ngraph_ir.bin");
+        cnnNetworkPtr->serialize("/tmp/ngraph_ir.xml", "/tmp/ngraph_ir.bin");
 #endif
         mPlugin = std::make_shared<IENetwork>(cnnNetworkPtr);
         mPlugin->loadNetwork();

--- a/ngraph_creator/operations/include/OperationsBase.hpp
+++ b/ngraph_creator/operations/include/OperationsBase.hpp
@@ -107,8 +107,11 @@ protected:
             input = mNgraphNodes->getOperationOutput(operandIndex).get_node_shared_ptr();
         }
 
-        if (operandType == OperandType::TENSOR_QUANT8_ASYMM && dequantize) {
-            input = DequantizeNode(input, operandIndex, ngraph::element::f32);
+        if (dequantize) {
+            if (operandType == OperandType::TENSOR_QUANT8_ASYMM ||
+                operandType == OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL) {
+                input = DequantizeNode(input, operandIndex, ngraph::element::f32);
+            }
         }
 
         return input;
@@ -136,7 +139,8 @@ protected:
 
     std::shared_ptr<ngraph::Node> QuantizeNode(std::shared_ptr<ngraph::Node> input, size_t index,
                                                ngraph::element::Type quantizeType);
-    std::shared_ptr<ngraph::Node> DequantizeNode(std::shared_ptr<ngraph::Node> input, size_t index,
+    std::shared_ptr<ngraph::Node> DequantizeNode(std::shared_ptr<ngraph::Node> input,
+                                                 uint32_t index,
                                                  ngraph::element::Type dequantizeType);
 
     const Operand& getInputOperand(uint32_t index) {

--- a/ngraph_creator/operations/src/Depthwise_Conv_2d.cpp
+++ b/ngraph_creator/operations/src/Depthwise_Conv_2d.cpp
@@ -192,19 +192,16 @@ std::shared_ptr<ngraph::Node> Depthwise_Conv_2d::createNode() {
         const auto& filterOperand = sModelInfo->getOperand(filterIndex);
         vec<float> filterScales = filterOperand.extraParams.channelQuant().scales;
         float inputScale = sModelInfo->getOperandScale(0);
-        auto filterScales_node =
+        auto filterScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{filterScales.size()}, filterScales);
-        auto inputScales_node =
+        auto inputScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{1}, convertToVector(inputScale));
-        auto filterNodeConvert =
-            std::make_shared<ngraph::opset3::Convert>(filterNode, ngraph::element::f32);
-        filterNode =
-            std::make_shared<ngraph::opset3::Multiply>(filterNodeConvert, filterScales_node);
+
         // for quant symm per channel type inputs, bias is of type TENSOR_INT32. For TENSOR_INT32
         // type, dequantization is not applied during node creation
         // bias_scale[i] = input_scale * filter_scale[i]
         auto biasScalMultiplier =
-            std::make_shared<ngraph::opset3::Multiply>(filterScales_node, inputScales_node);
+            std::make_shared<ngraph::opset3::Multiply>(filterScalesNode, inputScalesNode);
         biasNode = std::make_shared<ngraph::opset3::Convert>(biasNode, ngraph::element::f32);
         biasNode = std::make_shared<ngraph::opset3::Multiply>(biasNode, biasScalMultiplier);
     } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {

--- a/ngraph_creator/operations/src/Dequantize.cpp
+++ b/ngraph_creator/operations/src/Dequantize.cpp
@@ -17,96 +17,14 @@ bool Dequantize::validate() {
 
 std::shared_ptr<ngraph::Node> Dequantize::createNode() {
     // Creating input nodes
-    std::shared_ptr<ngraph::Node> input;
-
+    std::shared_ptr<ngraph::Node> input, outputNode;
     input = getInputNode(0, false);
-
     const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
 
-    std::shared_ptr<ngraph::Node> outputNode;
-
-    // TODO: create a generic function for all TENSOR_QUANT8_SYMM_PER_CHANNEL tensors
-    if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_SYMM_PER_CHANNEL)) {
-        const auto& inputOperand = sModelInfo->getOperand(inputIndex);
-        vec<float> inputScales = inputOperand.extraParams.channelQuant().scales;
-        auto channelDim = inputOperand.extraParams.channelQuant().channelDim;
-
-        std::shared_ptr<ngraph::Node> inputScales_node;
-
-        if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16)) {
-            input = std::make_shared<ngraph::opset3::Convert>(input, ngraph::element::f16);
-            inputScales_node = createConstNode(ngraph::element::f16,
-                                               ngraph::Shape{inputScales.size()}, inputScales);
-        } else {
-            input = std::make_shared<ngraph::opset3::Convert>(input, ngraph::element::f32);
-            inputScales_node = createConstNode(ngraph::element::f32,
-                                               ngraph::Shape{inputScales.size()}, inputScales);
-        }
-
-        const auto inputRank = getInputOperandDimensions(0).size();
-        if (channelDim == (inputRank - 1)) {
-            outputNode = std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-        } else {
-            if (inputRank == 4) {
-                switch (channelDim) {
-                    case 2:
-                        input = transpose(NHCW_NHWC, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(NHCW_NHWC, outputNode);
-                        break;
-                    case 1:
-                        input = transpose(NCHW_NHWC, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(NHWC_NCHW, outputNode);
-                        break;
-                    case 0:
-                        input = transpose(NHWC_CWHN, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(CWHN_NHWC, outputNode);
-                        break;
-                    default:
-                        break;
-                }
-            } else if (inputRank == 3) {
-                switch (channelDim) {
-                    case 1:
-                        input = transpose(NHC_NCH, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(NHC_NCH, outputNode);
-                        break;
-                    case 0:
-                        input = transpose(CNH_NHC, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(NHC_CNH, outputNode);
-                        break;
-                    default:
-                        break;
-                }
-            } else if (inputRank == 2) {
-                switch (channelDim) {
-                    case 0:
-                        input = transpose(NC_CN, input);
-                        outputNode =
-                            std::make_shared<ngraph::opset3::Multiply>(input, inputScales_node);
-                        outputNode = transpose(NC_CN, outputNode);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        }
-    } else {
-        if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16))
-            outputNode = DequantizeNode(input, inputIndex, ngraph::element::f16);
-
-        else
-            outputNode = DequantizeNode(input, inputIndex, ngraph::element::f32);
-    }
+    if (checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT16))
+        outputNode = DequantizeNode(input, inputIndex, ngraph::element::f16);
+    else
+        outputNode = DequantizeNode(input, inputIndex, ngraph::element::f32);
 
     return outputNode;
 }

--- a/ngraph_creator/operations/src/Grouped_Conv_2d.cpp
+++ b/ngraph_creator/operations/src/Grouped_Conv_2d.cpp
@@ -144,9 +144,6 @@ std::shared_ptr<ngraph::Node> Grouped_Conv_2d::createNode() {
     }
 
     std::shared_ptr<ngraph::Node> inputNode, filterNode, biasNode;
-
-    const auto& inputIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 0);
-    const auto& filterIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 1);
     const auto& biasIndex = sModelInfo->getOperationInput(mNnapiOperationIndex, 2);
 
     inputNode = getInputNode(0);
@@ -158,21 +155,16 @@ std::shared_ptr<ngraph::Node> Grouped_Conv_2d::createNode() {
         const auto& filterOperand = sModelInfo->getOperand(filterIndex);
         vec<float> filterScales = filterOperand.extraParams.channelQuant().scales;
         float inputScale = sModelInfo->getOperandScale(0);
-        auto filterScales_node =
+        auto filterScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{filterScales.size()}, filterScales);
-        auto inputScales_node =
+        auto inputScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{1}, convertToVector(inputScale));
-        filterNode = transpose(NHWC_CWHN, filterNode);
-        auto filterNodeConvert =
-            std::make_shared<ngraph::opset3::Convert>(filterNode, ngraph::element::f32);
-        auto filterNodeMulScales =
-            std::make_shared<ngraph::opset3::Multiply>(filterNodeConvert, filterScales_node);
-        filterNode = transpose(CWHN_NHWC, filterNodeMulScales);
+
         // for quant symm per channel type inputs, bias is of type TENSOR_INT32. For TENSOR_INT32
         // type, dequantization is not applied during node creation
         // bias_scale[i] = input_scale * filter_scale[i]
         auto biasScalMultiplier =
-            std::make_shared<ngraph::opset3::Multiply>(filterScales_node, inputScales_node);
+            std::make_shared<ngraph::opset3::Multiply>(filterScalesNode, inputScalesNode);
         biasNode = std::make_shared<ngraph::opset3::Convert>(biasNode, ngraph::element::f32);
         biasNode = std::make_shared<ngraph::opset3::Multiply>(biasNode, biasScalMultiplier);
     } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {

--- a/ngraph_creator/operations/src/Transpose_Conv_2D.cpp
+++ b/ngraph_creator/operations/src/Transpose_Conv_2D.cpp
@@ -157,21 +157,16 @@ std::shared_ptr<ngraph::Node> Transpose_Conv_2D::createNode() {
         const auto& filterOperand = sModelInfo->getOperand(filterIndex);
         vec<float> filterScales = filterOperand.extraParams.channelQuant().scales;
         float inputScale = sModelInfo->getOperandScale(0);
-        auto filterScales_node =
+        auto filterScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{filterScales.size()}, filterScales);
-        auto inputScales_node =
+        auto inputScalesNode =
             createConstNode(ngraph::element::f32, ngraph::Shape{1}, convertToVector(inputScale));
-        filterNode = transpose(NHWC_CWHN, filterNode);
-        auto filterNodeConvert =
-            std::make_shared<ngraph::opset3::Convert>(filterNode, ngraph::element::f32);
-        auto filterNodeMulScales =
-            std::make_shared<ngraph::opset3::Multiply>(filterNodeConvert, filterScales_node);
-        filterNode = transpose(CWHN_NHWC, filterNodeMulScales);
+
         // for quant symm per channel type inputs, bias is of type TENSOR_INT32. For TENSOR_INT32
         // type, dequantization is not applied during node creation
         // bias_scale[i] = input_scale * filter_scale[i]
         auto biasScalMultiplier =
-            std::make_shared<ngraph::opset3::Multiply>(filterScales_node, inputScales_node);
+            std::make_shared<ngraph::opset3::Multiply>(filterScalesNode, inputScalesNode);
         biasNode = std::make_shared<ngraph::opset3::Convert>(biasNode, ngraph::element::f32);
         biasNode = std::make_shared<ngraph::opset3::Multiply>(biasNode, biasScalMultiplier);
     } else if (checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {


### PR DESCRIPTION
While constructing the dequantize graph use conversion to FP32
instead of INT32
Add support for QUANT8_SYMM_PER_CHANNEL in Dequantize
Remove precision type restrictions on fullyconnected op

Signed-off-by: P Raviraj Sitaram <raviraj.p.sitaram@intel.com>