### PR TITLE
Add CI for clang-format checking

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -1,0 +1,12 @@
+name: clang format
+on: [push, pull_request]
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.4.0
+      with:
+        clang-format-version: '11'
+        check-path: 'nn-hal'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![clang format](https://github.com/intel/nn-hal/actions/workflows/clang_format_check.yml/badge.svg)](https://github.com/intel/actions/workflows/clang_format_check.yml)
+
 # Android Neural Networks HAL with OpenVINO supporting hardware accelerators such as /
 Intel® Math Kernel Library for Deep Neural Networks (Intel® MKL-DNN)
 
@@ -38,3 +40,10 @@ Create a pull request on github.com with your patch. Make sure your change is cl
 and passing ULTs.
 
 A maintainer will contact you if there are questions or concerns.
+
+## Coding Style
+
+Before committing any changes, run the following command to make sure proper coding style is followed:
+```
+    find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;
+```

--- a/coding_style.txt
+++ b/coding_style.txt
@@ -1,2 +1,0 @@
-# Before commiting any changes, run the following command to make sure proper coding style is followed
-find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\)' -exec clang-format -style=file -i {} \;


### PR DESCRIPTION
This github action checks the coding style in a PR and fails if it does not meet the coding style in the .clang-format file.
Maintainers should not merge the PR until the coding style is fixed and this action passes.
Refer to the Coding Style section in the README.md for more details.