### PR TITLE
Add Float16 support for Resize Bilinear and Resize Nearest Neighbor op

### DIFF
--- a/ngraph_creator/operations/src/ResizeBilinear.cpp
+++ b/ngraph_creator/operations/src/ResizeBilinear.cpp
@@ -11,18 +11,6 @@ ResizeBilinear::ResizeBilinear(int operationIndex) : OperationsBase(operationInd
 }
 
 bool ResizeBilinear::validate() {
-    // TODO Add FLOAT16 check when VPUX plugin is supported
-    if (!checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        ALOGE("%s check for output types failed", __func__);
-        return false;
-    }
-
-    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        return false;
-    }
-
     const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
     if (inputDimensionsSize != 4) {
         ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
@@ -73,8 +61,7 @@ std::shared_ptr<ngraph::Node> ResizeBilinear::createNode() {
 
     if (!useNchw) inputNode = transpose(NHWC_NCHW, inputNode);
     // FLOAT16 type check added for future when VPUX plugin support is added
-    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32) ||
-        checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32)) {
         // In tensorflow lite, resizing by size is supported. Scaling factors are
         // calculated based on output shape.
         attrs.shape_calculation_mode = ngraph::op::v4::Interpolate::ShapeCalcMode::sizes;
@@ -84,6 +71,14 @@ std::shared_ptr<ngraph::Node> ResizeBilinear::createNode() {
         out_height = (int)(input_height * height_scale);
         // Recalculating scaling factors here because of typecasting output shape to
         // integer
+        width_scale = (float)out_width / (float)input_width;
+        height_scale = (float)out_height / (float)input_height;
+    } else if (checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+        attrs.shape_calculation_mode = ngraph::op::v4::Interpolate::ShapeCalcMode::sizes;
+        width_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        height_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
+        out_width = (int)(input_width * width_scale);
+        out_height = (int)(input_height * height_scale);
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
     } else if (checkInputOperandType(1, (int32_t)OperandType::INT32)) {

--- a/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
+++ b/ngraph_creator/operations/src/ResizeNearestNeighbor.cpp
@@ -11,18 +11,6 @@ ResizeNearestNeighbor::ResizeNearestNeighbor(int operationIndex) : OperationsBas
 }
 
 bool ResizeNearestNeighbor::validate() {
-    // TODO Add FLOAT16 check when VPUX plugin is supported
-    if (!checkOutputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkOutputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        ALOGE("%s check for output types failed", __func__);
-        return false;
-    }
-
-    if (!checkInputOperandType(0, (int32_t)OperandType::TENSOR_FLOAT32) &&
-        !checkInputOperandType(0, (int32_t)OperandType::TENSOR_QUANT8_ASYMM)) {
-        return false;
-    }
-
     const auto& inputDimensionsSize = getInputOperandDimensions(0).size();
     if (inputDimensionsSize != 4) {
         ALOGE("%s Invalid dimensions size for input(%lu)", __func__, inputDimensionsSize);
@@ -73,8 +61,7 @@ std::shared_ptr<ngraph::Node> ResizeNearestNeighbor::createNode() {
 
     if (!useNchw) inputNode = transpose(NHWC_NCHW, inputNode);
     // FLOAT16 type check added for future when VPUX plugin support is added
-    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32) ||
-        checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+    if (checkInputOperandType(1, (int32_t)OperandType::FLOAT32)) {
         // In tensorflow lite, resizing by size is supported. Scaling factors are
         // calculated based on output shape.
         attrs.shape_calculation_mode = ngraph::op::v4::Interpolate::ShapeCalcMode::sizes;
@@ -84,6 +71,14 @@ std::shared_ptr<ngraph::Node> ResizeNearestNeighbor::createNode() {
         out_height = (int)(input_height * height_scale);
         // Recalculating scaling factors here because of typecasting output shape to
         // integer
+        width_scale = (float)out_width / (float)input_width;
+        height_scale = (float)out_height / (float)input_height;
+    } else if (checkInputOperandType(1, (int32_t)OperandType::FLOAT16)) {
+        attrs.shape_calculation_mode = ngraph::op::v4::Interpolate::ShapeCalcMode::sizes;
+        width_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 1);
+        height_scale = sModelInfo->ParseOperationInput<_Float16>(mNnapiOperationIndex, 2);
+        out_width = (int)(input_width * width_scale);
+        out_height = (int)(input_height * height_scale);
         width_scale = (float)out_width / (float)input_width;
         height_scale = (float)out_height / (float)input_height;
     } else if (checkInputOperandType(1, (int32_t)OperandType::INT32)) {


### PR DESCRIPTION
Adds Float16 support for ResizeBilinear and ResizeNearestNeighbor

Signed-off-by: Ritul Jasuja <ritul.jasuja@intel.com>