### PR TITLE
Remove enable-sep-transposed-conv from compilation params

### DIFF
--- a/IENetwork.cpp
+++ b/IENetwork.cpp
@@ -39,7 +39,7 @@ bool IENetwork::loadNetwork() {
     ALOGD("Creating infer request for Intel Device Type : %s", deviceStr.c_str());
     if (mNetwork) {
 	ov::AnyMap config;
-	config["NPU_COMPILATION_MODE_PARAMS"] = "enable-se-ptrs-operations=true enable-sep-transposed-conv=true";
+	config["NPU_COMPILATION_MODE_PARAMS"] = "enable-se-ptrs-operations=true";
 	compiled_model = ie.compile_model(mNetwork, deviceStr, config);
         ALOGD("LoadNetwork is done....");
 


### PR DESCRIPTION
Removes enable-sep-transposed-conv from compilation params as it's not supported